### PR TITLE
feat: click color presets

### DIFF
--- a/Sources/ClickLight/ClickOverlayView.swift
+++ b/Sources/ClickLight/ClickOverlayView.swift
@@ -230,6 +230,10 @@ final class ClickOverlayView: NSView {
     }
 
     private func color(for kind: ClickKind) -> NSColor {
+        if let color = settings.colorPreset.color {
+            return color
+        }
+
         switch kind {
         case .leftDown:
             return NSColor(calibratedRed: 0.0, green: 0.74, blue: 1.0, alpha: 1)

--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -9,6 +9,7 @@ struct ClickSettings: Equatable {
     var size: CGFloat
     var intensity: CGFloat
     var duration: TimeInterval
+    var colorPreset: ClickColorPreset
 
     static let defaults = ClickSettings(
         isEnabled: true,
@@ -18,8 +19,57 @@ struct ClickSettings: Equatable {
         showDrag: true,
         size: 64,
         intensity: 0.9,
-        duration: 0.48
+        duration: 0.48,
+        colorPreset: .default
     )
+}
+
+enum ClickColorPreset: String, CaseIterable, Equatable {
+    case `default`
+    case blue
+    case green
+    case purple
+    case pink
+    case orange
+    case white
+
+    var title: String {
+        switch self {
+        case .default:
+            return "Default"
+        case .blue:
+            return "Blue"
+        case .green:
+            return "Green"
+        case .purple:
+            return "Purple"
+        case .pink:
+            return "Pink"
+        case .orange:
+            return "Orange"
+        case .white:
+            return "White"
+        }
+    }
+
+    var color: NSColor? {
+        switch self {
+        case .default:
+            return nil
+        case .blue:
+            return NSColor(calibratedRed: 0.0, green: 0.74, blue: 1.0, alpha: 1)
+        case .green:
+            return NSColor(calibratedRed: 0.2, green: 0.9, blue: 0.42, alpha: 1)
+        case .purple:
+            return NSColor(calibratedRed: 0.58, green: 0.36, blue: 1.0, alpha: 1)
+        case .pink:
+            return NSColor(calibratedRed: 1.0, green: 0.32, blue: 0.72, alpha: 1)
+        case .orange:
+            return NSColor(calibratedRed: 1.0, green: 0.46, blue: 0.19, alpha: 1)
+        case .white:
+            return NSColor(calibratedWhite: 1.0, alpha: 1)
+        }
+    }
 }
 
 @MainActor
@@ -35,6 +85,7 @@ final class SettingsStore {
         static let size = "size"
         static let intensity = "intensity"
         static let duration = "duration"
+        static let colorPreset = "colorPreset"
     }
 
     private let defaults: UserDefaults
@@ -54,7 +105,8 @@ final class SettingsStore {
                 showDrag: defaults.bool(forKey: Key.showDrag),
                 size: CGFloat(defaults.double(forKey: Key.size)),
                 intensity: CGFloat(defaults.double(forKey: Key.intensity)),
-                duration: defaults.double(forKey: Key.duration)
+                duration: defaults.double(forKey: Key.duration),
+                colorPreset: ClickColorPreset(rawValue: defaults.string(forKey: Key.colorPreset) ?? "") ?? .default
             )
         }
         set {
@@ -66,6 +118,7 @@ final class SettingsStore {
             defaults.set(Double(newValue.size), forKey: Key.size)
             defaults.set(Double(newValue.intensity), forKey: Key.intensity)
             defaults.set(newValue.duration, forKey: Key.duration)
+            defaults.set(newValue.colorPreset.rawValue, forKey: Key.colorPreset)
             NotificationCenter.default.post(name: Self.didChangeNotification, object: self)
         }
     }
@@ -86,7 +139,8 @@ final class SettingsStore {
             Key.showDrag: defaults.showDrag,
             Key.size: Double(defaults.size),
             Key.intensity: Double(defaults.intensity),
-            Key.duration: defaults.duration
+            Key.duration: defaults.duration,
+            Key.colorPreset: defaults.colorPreset.rawValue
         ])
     }
 }

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -113,6 +113,7 @@ final class StatusController {
             selected: settings.duration,
             action: #selector(selectDuration(_:))
         ))
+        menu.addItem(colorSubmenu(selected: settings.colorPreset))
         menu.addItem(NSMenuItem.separator())
 
         let captureItem = NSMenuItem(title: "Click Capture: \(captureStatus())", action: nil, keyEquivalent: "")
@@ -174,6 +175,20 @@ final class StatusController {
         return item
     }
 
+    private func colorSubmenu(selected: ClickColorPreset) -> NSMenuItem {
+        let item = NSMenuItem(title: "Colors", action: nil, keyEquivalent: "")
+        let menu = NSMenu()
+        for preset in ClickColorPreset.allCases {
+            let child = NSMenuItem(title: preset.title, action: #selector(selectColor(_:)), keyEquivalent: "")
+            child.target = self
+            child.representedObject = preset.rawValue
+            child.state = preset == selected ? .on : .off
+            menu.addItem(child)
+        }
+        item.submenu = menu
+        return item
+    }
+
     @objc private func toggleEnabled() {
         settingsStore.update { $0.isEnabled.toggle() }
     }
@@ -207,6 +222,14 @@ final class StatusController {
     @objc private func selectDuration(_ sender: NSMenuItem) {
         guard let value = sender.representedObject as? Double else { return }
         settingsStore.update { $0.duration = value }
+    }
+
+    @objc private func selectColor(_ sender: NSMenuItem) {
+        guard
+            let rawValue = sender.representedObject as? String,
+            let preset = ClickColorPreset(rawValue: rawValue)
+        else { return }
+        settingsStore.update { $0.colorPreset = preset }
     }
 
     @objc private func openAccessibilitySettings() {


### PR DESCRIPTION
One more idea, might be useful too:
Introduce ClickColorPreset and wire it into settings and UI so users can pick predefined colors for click overlays. Persist the chosen preset in UserDefaults via SettingsStore (with safe fallback to .default), expose a "Colors" submenu in the status menu with selection handling, and have ClickOverlayView use the selected preset (falling back to the existing per-kind colors when preset is .default).