### PR TITLE
fix: default intensity menu checkmark on first launch

### DIFF
--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -20,7 +20,7 @@ struct ClickSettings: Equatable {
         showDrag: true,
         showMenuBarText: true,
         size: 64,
-        intensity: 0.9,
+        intensity: 0.7,
         duration: 0.48,
         colorPreset: .default
     )


### PR DESCRIPTION
Randomly I found one tiny issue:
The default intensity value in `SettingsStore.swift` (line 23) should match one of the intensity option values defined in `StatusController.swift` (lines 104 - 107).
Specifically, `ClickSettings.defaults.intensity` is the value used on first launch, while the “Intensity” submenu marks an item as selected **only** when that value matches one of its option values. If these values differ, **no checkmark is shown initially**.

So the minimal change:
Sets the default intensity to match the existing “Normal” intensity menu option. This ensures that the checkmark in the “Intensity” selection menu is visible next to “Normal” on first launch.

Before:
<img width="376" height="309" alt="Before" src="https://github.com/user-attachments/assets/a0df77bc-12f2-4562-a630-5f3313464c34" />

After:
<img width="385" height="440" alt="After" src="https://github.com/user-attachments/assets/45b0c398-5dc8-43ad-a7a0-99b5335ff2d8" />
