### PR TITLE
launch-at-login functionality

### DIFF
--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -8,6 +8,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private lazy var statusController = StatusController(
         settingsStore: settingsStore,
         permissions: permissions,
+        launchAtLogin: launchAtLogin,
         captureStatus: { [weak self] in self?.captureController.statusLabel ?? "Not Started" },
         onCheckForUpdates: { UpdateChecker.shared.checkForUpdates() },
         updatesAreConfigured: { UpdateChecker.shared.isConfigured },
@@ -16,6 +17,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     )
     private let eventTap = ClickEventTap()
     private let permissions = PermissionController()
+    private let launchAtLogin = LaunchAtLoginController()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         overlayCoordinator.start()

--- a/Sources/ClickLight/LaunchAtLoginController.swift
+++ b/Sources/ClickLight/LaunchAtLoginController.swift
@@ -1,0 +1,29 @@
+import Foundation
+import ServiceManagement
+
+@MainActor
+protocol LaunchAtLoginManaging {
+    var isEnabled: Bool { get }
+    func setEnabled(_ enabled: Bool) throws
+}
+
+enum LaunchAtLoginState {
+    static func toggledValue(currentlyEnabled: Bool) -> Bool {
+        !currentlyEnabled
+    }
+}
+
+@MainActor
+final class LaunchAtLoginController: LaunchAtLoginManaging {
+    var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    func setEnabled(_ enabled: Bool) throws {
+        if enabled {
+            try SMAppService.mainApp.register()
+        } else {
+            try SMAppService.mainApp.unregister()
+        }
+    }
+}

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -5,6 +5,7 @@ final class StatusController {
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     private let settingsStore: SettingsStore
     private let permissions: PermissionController
+    private let launchAtLogin: LaunchAtLoginManaging
     private let captureStatus: () -> String
     private let onCheckForUpdates: () -> Void
     private let updatesAreConfigured: () -> Bool
@@ -14,6 +15,7 @@ final class StatusController {
     init(
         settingsStore: SettingsStore,
         permissions: PermissionController,
+        launchAtLogin: LaunchAtLoginManaging,
         captureStatus: @escaping () -> String,
         onCheckForUpdates: @escaping () -> Void,
         updatesAreConfigured: @escaping () -> Bool,
@@ -22,6 +24,7 @@ final class StatusController {
     ) {
         self.settingsStore = settingsStore
         self.permissions = permissions
+        self.launchAtLogin = launchAtLogin
         self.captureStatus = captureStatus
         self.onCheckForUpdates = onCheckForUpdates
         self.updatesAreConfigured = updatesAreConfigured
@@ -84,6 +87,11 @@ final class StatusController {
             title: "Show Menu Bar Text",
             isOn: settings.showMenuBarText,
             action: #selector(toggleMenuBarText)
+        ))
+        menu.addItem(toggleItem(
+            title: "Launch at Login",
+            isOn: launchAtLogin.isEnabled,
+            action: #selector(toggleLaunchAtLogin)
         ))
         menu.addItem(NSMenuItem.separator())
 
@@ -224,6 +232,16 @@ final class StatusController {
 
     @objc private func toggleMenuBarText() {
         settingsStore.update { $0.showMenuBarText.toggle() }
+    }
+
+    @objc private func toggleLaunchAtLogin() {
+        let enabled = LaunchAtLoginState.toggledValue(currentlyEnabled: launchAtLogin.isEnabled)
+        do {
+            try launchAtLogin.setEnabled(enabled)
+        } catch {
+            NSLog("ClickLight: Failed to update launch at login: \(error)")
+        }
+        rebuildMenu()
     }
 
     @objc private func selectSize(_ sender: NSMenuItem) {


### PR DESCRIPTION
Hey, so I got one little maybe useful feature:

**Launch at login support**: When enabled, ClickLight automatically starts after the user logs into macOS, and when disabled, it is removed from the login items again.

The implementation introduces a dedicated `LaunchAtLoginController` to keep the system API isolated from the menu UI. `StatusController` now reads the actual login-item status to show the checkmark and toggles registration when the menu item is clicked.

For setting up an controlling I added another toggle:
<img width="270" height="330" alt="Bildschirmfoto 2026-05-25 um 14 11 58" src="https://github.com/user-attachments/assets/8ad01fd7-aa7c-41d3-b8dc-cdacef81eeff" />

Let me know what you think 👍 