### PR TITLE
disable test pulse when ClickLight is disabled

### DIFF
--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -54,6 +54,7 @@ final class StatusController {
     private func rebuildMenu() {
         let settings = settingsStore.settings
         let menu = NSMenu()
+        StatusMenuConfiguration.apply(to: menu)
 
         menu.addItem(toggleItem(
             title: "Enabled",
@@ -137,6 +138,7 @@ final class StatusController {
 
         let testPulseItem = NSMenuItem(title: "Test Pulse at Pointer", action: #selector(testPulse), keyEquivalent: "")
         testPulseItem.target = self
+        testPulseItem.isEnabled = StatusMenuAvailability.isTestPulseEnabled(isClickLightEnabled: settings.isEnabled)
         menu.addItem(testPulseItem)
         menu.addItem(NSMenuItem.separator())
 

--- a/Sources/ClickLight/StatusMenuAvailability.swift
+++ b/Sources/ClickLight/StatusMenuAvailability.swift
@@ -1,0 +1,5 @@
+enum StatusMenuAvailability {
+    static func isTestPulseEnabled(isClickLightEnabled: Bool) -> Bool {
+        isClickLightEnabled
+    }
+}

--- a/Sources/ClickLight/StatusMenuConfiguration.swift
+++ b/Sources/ClickLight/StatusMenuConfiguration.swift
@@ -1,0 +1,7 @@
+import AppKit
+
+enum StatusMenuConfiguration {
+    static func apply(to menu: NSMenu) {
+        menu.autoenablesItems = false
+    }
+}


### PR DESCRIPTION
Again, one little adjustment to the button logic:
This change disables the *Test Pulse at Pointer* menu item when ClickLight itself is disabled. This makes sure, that the user can only test a pulse with visible feedback when ClickLight itself is enabled.

Before - *Test Pulse at Pointer*: Visual Feedback not visible but menu item is clickable
<img width="275" height="495" alt="Before" src="https://github.com/user-attachments/assets/492c25ae-22b3-4002-97cc-a4781eeb5f7b" />

After - *Test Pulse at Pointer*:  Visual Feedback not visible and menu item not clickable
<img width="300" height="424" alt="After" src="https://github.com/user-attachments/assets/d8211afa-bbce-4041-a5e3-0e99b5d7c9fe" />

I think this might be a small adjustment for UX improvement but please let me know if there's another intended behavior :)