### PR TITLE
Change showMenuBarText setting to false

### DIFF
--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -18,7 +18,7 @@ struct ClickSettings: Equatable {
         showRelease: true,
         showRightClick: true,
         showDrag: true,
-        showMenuBarText: true,
+        showMenuBarText: false,
         size: 64,
         intensity: 0.7,
         duration: 0.48,


### PR DESCRIPTION
Aligns better with mac defaults, up to you, but I feel like the text isnt' very macOS