### PR TITLE
Refactor app icon generation and remove obsolete script

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -9,7 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.aurorascharff.ClickLight</string>
     <key>CFBundleIconFile</key>
-    <string>ClickLight</string>
+    <string>AppIcon</string>
+    <key>CFBundleIconName</key>
+    <string>AppIcon</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>

--- a/build-app.sh
+++ b/build-app.sh
@@ -33,6 +33,37 @@ ICONSET_DIR="$BUILD_DIR/$APP_NAME.iconset"
 ICON_PARTIAL_PLIST="$BUILD_DIR/AppIcon-partial.plist"
 ICON_RESOURCE_NAME="AppIcon"
 
+ensure_fallback_icon_inputs() {
+    local missing_context="$1"
+
+    if [ ! -f "$ICON_SOURCE" ]; then
+        echo "$missing_context icon source is missing: $ICON_SOURCE"
+        exit 1
+    fi
+
+    if [ ! -f "$ICON_RENDER_SCRIPT" ]; then
+        echo "$missing_context app icon renderer is missing: $ICON_RENDER_SCRIPT"
+        exit 1
+    fi
+}
+
+generate_fallback_icns() {
+    rm -rf "$ICONSET_DIR"
+    mkdir -p "$ICONSET_DIR"
+    swift "$ICON_RENDER_SCRIPT" "$ICON_SOURCE" "$ICON_RENDERED_SOURCE"
+    sips -z 16 16 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_16x16.png" >/dev/null
+    sips -z 32 32 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_16x16@2x.png" >/dev/null
+    sips -z 32 32 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_32x32.png" >/dev/null
+    sips -z 64 64 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_32x32@2x.png" >/dev/null
+    sips -z 128 128 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_128x128.png" >/dev/null
+    sips -z 256 256 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_128x128@2x.png" >/dev/null
+    sips -z 256 256 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_256x256.png" >/dev/null
+    sips -z 512 512 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_256x256@2x.png" >/dev/null
+    sips -z 512 512 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_512x512.png" >/dev/null
+    sips -z 1024 1024 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_512x512@2x.png" >/dev/null
+    iconutil --convert icns "$ICONSET_DIR" --output "$APP_DIR/Contents/Resources/$ICON_RESOURCE_NAME.icns"
+}
+
 VERSION="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.1.0")"
 
 swift build -c "$CONFIGURATION"
@@ -61,41 +92,25 @@ if command -v xcrun >/dev/null 2>&1 && xcrun --find actool >/dev/null 2>&1; then
         --platform macosx \
         --target-device mac \
         --minimum-deployment-target 14.0 \
+        --standalone-icon-behavior all \
         --include-all-app-icons \
         --output-partial-info-plist "$ICON_PARTIAL_PLIST" \
         --output-format human-readable-text
 
     rm -f "$ICON_PARTIAL_PLIST"
 
+    if [ ! -f "$APP_DIR/Contents/Resources/$ICON_RESOURCE_NAME.icns" ]; then
+        ensure_fallback_icon_inputs "actool did not produce $ICON_RESOURCE_NAME.icns and fallback"
+        generate_fallback_icns
+    fi
+
     if [ ! -f "$APP_DIR/Contents/Resources/$ICON_RESOURCE_NAME.icns" ] && [ ! -f "$APP_DIR/Contents/Resources/Assets.car" ]; then
-        echo "actool did not produce an app icon output."
+        echo "actool and fallback generation did not produce an app icon output."
         exit 1
     fi
 else
-    if [ ! -f "$ICON_SOURCE" ]; then
-        echo "Missing fallback app icon source: $ICON_SOURCE"
-        exit 1
-    fi
-
-    if [ ! -f "$ICON_RENDER_SCRIPT" ]; then
-        echo "Missing fallback app icon renderer: $ICON_RENDER_SCRIPT"
-        exit 1
-    fi
-
-    rm -rf "$ICONSET_DIR"
-    mkdir -p "$ICONSET_DIR"
-    swift "$ICON_RENDER_SCRIPT" "$ICON_SOURCE" "$ICON_RENDERED_SOURCE"
-    sips -z 16 16 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_16x16.png" >/dev/null
-    sips -z 32 32 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_16x16@2x.png" >/dev/null
-    sips -z 32 32 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_32x32.png" >/dev/null
-    sips -z 64 64 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_32x32@2x.png" >/dev/null
-    sips -z 128 128 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_128x128.png" >/dev/null
-    sips -z 256 256 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_128x128@2x.png" >/dev/null
-    sips -z 256 256 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_256x256.png" >/dev/null
-    sips -z 512 512 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_256x256@2x.png" >/dev/null
-    sips -z 512 512 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_512x512.png" >/dev/null
-    sips -z 1024 1024 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_512x512@2x.png" >/dev/null
-    iconutil --convert icns "$ICONSET_DIR" --output "$APP_DIR/Contents/Resources/$ICON_RESOURCE_NAME.icns"
+    ensure_fallback_icon_inputs "Missing fallback"
+    generate_fallback_icns
 fi
 
 SPARKLE_PATH="$(find "$ROOT_DIR/.build" -name "Sparkle.framework" -type d | head -1)"

--- a/build-app.sh
+++ b/build-app.sh
@@ -25,10 +25,13 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="$ROOT_DIR/.build/$CONFIGURATION"
 APP_DIR="$ROOT_DIR/$APP_NAME.app"
 ZIP_PATH="$ROOT_DIR/$APP_NAME.zip"
-ICON_SOURCE="$ROOT_DIR/AppIcon.icon/Assets/ClickLight-icon.png"
+ICON_BUNDLE="$ROOT_DIR/AppIcon.icon"
+ICON_SOURCE="$ICON_BUNDLE/Assets/ClickLight-icon.png"
 ICON_RENDER_SCRIPT="$ROOT_DIR/scripts/render-icon.swift"
 ICON_RENDERED_SOURCE="$BUILD_DIR/$APP_NAME-rendered-icon.png"
 ICONSET_DIR="$BUILD_DIR/$APP_NAME.iconset"
+ICON_PARTIAL_PLIST="$BUILD_DIR/AppIcon-partial.plist"
+ICON_RESOURCE_NAME="AppIcon"
 
 VERSION="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.1.0")"
 
@@ -44,30 +47,56 @@ cp "$ROOT_DIR/Info.plist" "$APP_DIR/Contents/Info.plist"
 
 cp "$BUILD_DIR/$APP_NAME" "$APP_DIR/Contents/MacOS/$APP_NAME"
 
-if [ ! -f "$ICON_SOURCE" ]; then
-    echo "Missing app icon source: $ICON_SOURCE"
+if [ ! -d "$ICON_BUNDLE" ]; then
+    echo "Missing app icon bundle: $ICON_BUNDLE"
     exit 1
 fi
 
-if [ ! -f "$ICON_RENDER_SCRIPT" ]; then
-    echo "Missing app icon renderer: $ICON_RENDER_SCRIPT"
-    exit 1
-fi
+rm -f "$APP_DIR/Contents/Resources/$ICON_RESOURCE_NAME.icns" "$APP_DIR/Contents/Resources/Assets.car" "$ICON_PARTIAL_PLIST"
 
-rm -rf "$ICONSET_DIR"
-mkdir -p "$ICONSET_DIR"
-swift "$ICON_RENDER_SCRIPT" "$ICON_SOURCE" "$ICON_RENDERED_SOURCE"
-sips -z 16 16 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_16x16.png" >/dev/null
-sips -z 32 32 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_16x16@2x.png" >/dev/null
-sips -z 32 32 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_32x32.png" >/dev/null
-sips -z 64 64 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_32x32@2x.png" >/dev/null
-sips -z 128 128 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_128x128.png" >/dev/null
-sips -z 256 256 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_128x128@2x.png" >/dev/null
-sips -z 256 256 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_256x256.png" >/dev/null
-sips -z 512 512 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_256x256@2x.png" >/dev/null
-sips -z 512 512 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_512x512.png" >/dev/null
-sips -z 1024 1024 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_512x512@2x.png" >/dev/null
-iconutil --convert icns "$ICONSET_DIR" --output "$APP_DIR/Contents/Resources/$APP_NAME.icns"
+if command -v xcrun >/dev/null 2>&1 && xcrun --find actool >/dev/null 2>&1; then
+    xcrun actool "$ICON_BUNDLE" \
+        --compile "$APP_DIR/Contents/Resources" \
+        --app-icon "$ICON_RESOURCE_NAME" \
+        --platform macosx \
+        --target-device mac \
+        --minimum-deployment-target 14.0 \
+        --include-all-app-icons \
+        --output-partial-info-plist "$ICON_PARTIAL_PLIST" \
+        --output-format human-readable-text
+
+    rm -f "$ICON_PARTIAL_PLIST"
+
+    if [ ! -f "$APP_DIR/Contents/Resources/$ICON_RESOURCE_NAME.icns" ] && [ ! -f "$APP_DIR/Contents/Resources/Assets.car" ]; then
+        echo "actool did not produce an app icon output."
+        exit 1
+    fi
+else
+    if [ ! -f "$ICON_SOURCE" ]; then
+        echo "Missing fallback app icon source: $ICON_SOURCE"
+        exit 1
+    fi
+
+    if [ ! -f "$ICON_RENDER_SCRIPT" ]; then
+        echo "Missing fallback app icon renderer: $ICON_RENDER_SCRIPT"
+        exit 1
+    fi
+
+    rm -rf "$ICONSET_DIR"
+    mkdir -p "$ICONSET_DIR"
+    swift "$ICON_RENDER_SCRIPT" "$ICON_SOURCE" "$ICON_RENDERED_SOURCE"
+    sips -z 16 16 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_16x16.png" >/dev/null
+    sips -z 32 32 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_16x16@2x.png" >/dev/null
+    sips -z 32 32 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_32x32.png" >/dev/null
+    sips -z 64 64 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_32x32@2x.png" >/dev/null
+    sips -z 128 128 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_128x128.png" >/dev/null
+    sips -z 256 256 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_128x128@2x.png" >/dev/null
+    sips -z 256 256 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_256x256.png" >/dev/null
+    sips -z 512 512 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_256x256@2x.png" >/dev/null
+    sips -z 512 512 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_512x512.png" >/dev/null
+    sips -z 1024 1024 "$ICON_RENDERED_SOURCE" --out "$ICONSET_DIR/icon_512x512@2x.png" >/dev/null
+    iconutil --convert icns "$ICONSET_DIR" --output "$APP_DIR/Contents/Resources/$ICON_RESOURCE_NAME.icns"
+fi
 
 SPARKLE_PATH="$(find "$ROOT_DIR/.build" -name "Sparkle.framework" -type d | head -1)"
 if [ -n "$SPARKLE_PATH" ]; then

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -59,6 +59,8 @@ ClickLight.app
 
 and signs the app bundle. Local builds use ad-hoc signing by default. Release builds can use Developer ID signing and notarization when the required Apple credentials are configured.
 
+For app icons, `build-app.sh` now treats `AppIcon.icon` as the source of truth. On newer macOS toolchains it compiles that bundle with `actool`, which produces the modern asset output plus the fallback `.icns` file. If `actool` is unavailable, it falls back to the older manual `.icns` generation path.
+
 This works without Xcode because Xcode is not the compiler. The app uses AppKit and CoreGraphics APIs directly from Swift, and Swift Package Manager can build it from the command line.
 
 ## Useful Files


### PR DESCRIPTION
This pull request updates the app icon build process to use Apple's standard asset catalog tooling (`actool`) while preserving a robust fallback path for icon reliability.

<img width="1230" height="399" alt="image" src="https://github.com/user-attachments/assets/ec83b9c3-7ace-4c31-9784-b7ce574a449a" />

**App Icon Build Process Modernization**

* The build script (`build-app.sh`) now treats `AppIcon.icon` as the source of truth and uses `xcrun actool` to compile icon assets.
* `Info.plist` is updated to use standard `AppIcon` naming (`CFBundleIconFile` and `CFBundleIconName`), improving compatibility with macOS app packaging.
* The actool invocation now explicitly uses `--standalone-icon-behavior all` so loose icon output is complete and consistent for macOS tools that read standalone icon files.

**Fallback and Resilience Improvements**

* If `actool` is unavailable, packaging falls back to manual `.icns` generation from `AppIcon.icon/Assets/ClickLight-icon.png`.
* If `actool` runs but does not produce `AppIcon.icns`, the script now automatically regenerates a full `.icns` via the existing renderer + `sips` + `iconutil` pipeline.
* Icon fallback generation logic has been deduplicated in the build script to reduce maintenance overhead while keeping behavior unchanged.

**Documentation Update**

* Local development docs clarify that `AppIcon.icon` is compiled with `actool` during packaging, with fallback `.icns` generation when needed.

Together, these changes modernize icon handling and keep packaging robust across differing local macOS toolchains.
