### PR TITLE
Update macOS runner version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build:
     name: Build, sign, notarize, and publish
-    runs-on: macos-latest
+    runs-on: macos-26
     environment: release
     permissions:
       contents: write # Required to push release metadata and create the GitHub Release.


### PR DESCRIPTION
this should now build against latest xcode so get modern look and feel

latest is building off Xcode 16: https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md

macos-26 will use xcode 26: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md