### PR TITLE
Add laser pointer drawing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Prefer not to use Homebrew? Download `ClickLight.zip` from [GitHub Releases](htt
 
 - Click highlights across macOS apps
 - Separate visuals for press, release, right-click, and drag
+- Optional laser pointer mode with fading freehand strokes while dragging
 - Dedicated settings window with sliders + presets for size, duration, intensity, and color
 - Custom color picker in Settings
 - Menu-bar quick presets for size, duration, intensity, and color

--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -21,11 +21,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let permissions = PermissionController()
     private let launchAtLogin = LaunchAtLoginController()
     private var captureEnabledState: Bool?
+    private var laserPointerEnabledState: Bool?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         overlayCoordinator.start()
         permissions.requestAccessibilityIfNeeded()
         captureEnabledState = settingsStore.settings.isEnabled
+        laserPointerEnabledState = settingsStore.settings.showLaserPointer
         captureController.startIfEnabled()
         statusController.start()
 
@@ -49,9 +51,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func settingsDidChange() {
         overlayCoordinator.refreshSettings()
-        let isEnabled = settingsStore.settings.isEnabled
-        guard captureEnabledState != isEnabled else { return }
+        let settings = settingsStore.settings
+        let isEnabled = settings.isEnabled
+        let laserPointerEnabled = settings.showLaserPointer
+        guard captureEnabledState != isEnabled || laserPointerEnabledState != laserPointerEnabled else { return }
         captureEnabledState = isEnabled
+        laserPointerEnabledState = laserPointerEnabled
         captureController.refreshEnabledState()
     }
 

--- a/Sources/ClickLight/ClickCaptureController.swift
+++ b/Sources/ClickLight/ClickCaptureController.swift
@@ -3,7 +3,7 @@ import Foundation
 protocol ClickEventCapturing: AnyObject {
     var statusLabel: String { get }
 
-    func start()
+    func start(laserPointerEnabled: Bool)
     func stop()
 }
 
@@ -23,12 +23,12 @@ final class ClickCaptureController {
 
     func startIfEnabled() {
         guard settingsStore.settings.isEnabled else { return }
-        eventTap.start()
+        eventTap.start(laserPointerEnabled: settingsStore.settings.showLaserPointer)
     }
 
     func refreshEnabledState() {
         if settingsStore.settings.isEnabled {
-            eventTap.start()
+            eventTap.start(laserPointerEnabled: settingsStore.settings.showLaserPointer)
         } else {
             eventTap.stop()
         }

--- a/Sources/ClickLight/ClickEvent.swift
+++ b/Sources/ClickLight/ClickEvent.swift
@@ -6,6 +6,7 @@ enum ClickKind: Sendable {
     case rightDown
     case rightUp
     case drag
+    case move
 
     var isRelease: Bool {
         self == .leftUp || self == .rightUp

--- a/Sources/ClickLight/ClickEventTap.swift
+++ b/Sources/ClickLight/ClickEventTap.swift
@@ -6,6 +6,7 @@ final class ClickEventTap: ClickEventCapturing {
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var globalMonitor: Any?
+    private var laserPointerEnabled = false
 
     var statusLabel: String {
         switch (eventTap != nil, globalMonitor != nil) {
@@ -20,7 +21,11 @@ final class ClickEventTap: ClickEventCapturing {
         }
     }
 
-    func start() {
+    func start(laserPointerEnabled: Bool) {
+        if self.laserPointerEnabled != laserPointerEnabled {
+            stop()
+            self.laserPointerEnabled = laserPointerEnabled
+        }
         startEventTapIfNeeded()
         startGlobalMonitorIfNeeded()
     }
@@ -33,7 +38,7 @@ final class ClickEventTap: ClickEventCapturing {
     private func startEventTapIfNeeded() {
         guard eventTap == nil else { return }
 
-        let mask = [
+        var types = [
             CGEventType.leftMouseDown,
             CGEventType.leftMouseUp,
             CGEventType.rightMouseDown,
@@ -41,7 +46,11 @@ final class ClickEventTap: ClickEventCapturing {
             CGEventType.leftMouseDragged,
             CGEventType.rightMouseDragged,
             CGEventType.otherMouseDragged
-        ].reduce(CGEventMask(0)) { partial, eventType in
+        ]
+        if laserPointerEnabled {
+            types.append(.mouseMoved)
+        }
+        let mask = types.reduce(CGEventMask(0)) { partial, eventType in
             partial | (1 << CGEventMask(eventType.rawValue))
         }
 
@@ -82,7 +91,7 @@ final class ClickEventTap: ClickEventCapturing {
     private func startGlobalMonitorIfNeeded() {
         guard globalMonitor == nil else { return }
 
-        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: [
+        var eventTypes: NSEvent.EventTypeMask = [
             .leftMouseDown,
             .leftMouseUp,
             .rightMouseDown,
@@ -90,7 +99,12 @@ final class ClickEventTap: ClickEventCapturing {
             .leftMouseDragged,
             .rightMouseDragged,
             .otherMouseDragged
-        ]) { event in
+        ]
+        if laserPointerEnabled {
+            eventTypes.insert(.mouseMoved)
+        }
+
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: eventTypes) { event in
             guard let kind = ClickKind(event: event) else { return }
             Self.post(kind: kind, timestamp: event.timestamp)
         }
@@ -159,6 +173,8 @@ private extension ClickKind {
             self = .rightUp
         case .leftMouseDragged, .rightMouseDragged, .otherMouseDragged:
             self = .drag
+        case .mouseMoved:
+            self = .move
         default:
             return nil
         }
@@ -176,6 +192,8 @@ private extension ClickKind {
             self = .rightUp
         case .leftMouseDragged, .rightMouseDragged, .otherMouseDragged:
             self = .drag
+        case .mouseMoved:
+            self = .move
         default:
             return nil
         }

--- a/Sources/ClickLight/ClickLightSettingsView.swift
+++ b/Sources/ClickLight/ClickLightSettingsView.swift
@@ -255,6 +255,14 @@ struct ClickLightSettingsView: View {
     private var eventsPane: some View {
         SettingsCard {
             VStack(spacing: 0) {
+                ModernRow(title: "Laser Pointer Mode",
+                          subtitle: "Show a fading red pointer and draw temporary strokes while dragging.") {
+                    Toggle("", isOn: binding(\.showLaserPointer))
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .accessibilityLabel("Laser Pointer Mode")
+                }
+                Divider().padding(.vertical, 6)
                 ModernRow(title: "Show Press",
                           subtitle: "Highlight when the mouse button goes down.") {
                     Toggle("", isOn: binding(\.showPress))
@@ -280,11 +288,14 @@ struct ClickLightSettingsView: View {
                 }
                 Divider().padding(.vertical, 6)
                 ModernRow(title: "Show Drag",
-                          subtitle: "Trail pointer movement while dragging.") {
+                          subtitle: viewModel.settings.showLaserPointer
+                              ? "Laser Pointer Mode replaces the normal drag trail."
+                              : "Trail pointer movement while dragging.") {
                     Toggle("", isOn: binding(\.showDrag))
                         .toggleStyle(.switch)
                         .labelsHidden()
                         .accessibilityLabel("Show Drag")
+                        .disabled(viewModel.settings.showLaserPointer)
                 }
             }
         }

--- a/Sources/ClickLight/ClickOverlayView.swift
+++ b/Sources/ClickLight/ClickOverlayView.swift
@@ -4,6 +4,9 @@ final class ClickOverlayView: NSView {
     private var screenFrame: CGRect
     private var settings: ClickSettings
     private var pulses: [ClickPulse] = []
+    private var laserCursor: LaserCursor?
+    private var activeLaserStroke: LaserStroke?
+    private var completedLaserStrokes: [LaserStroke] = []
     private var displayLink: Timer?
 
     init(screenFrame: CGRect, settings: ClickSettings) {
@@ -20,6 +23,12 @@ final class ClickOverlayView: NSView {
 
     func apply(settings: ClickSettings) {
         self.settings = settings
+        if !settings.showLaserPointer {
+            laserCursor = nil
+            activeLaserStroke = nil
+            completedLaserStrokes = []
+            needsDisplay = true
+        }
     }
 
     func show(event: ClickEvent, settings: ClickSettings) {
@@ -29,6 +38,23 @@ final class ClickOverlayView: NSView {
             x: event.location.x - screenFrame.minX,
             y: event.location.y - screenFrame.minY
         )
+
+        if settings.showLaserPointer {
+            switch event.kind {
+            case .move:
+                showLaserCursor(at: localPoint)
+                return
+            case .drag:
+                appendLaserPoint(localPoint)
+                return
+            case .leftUp, .rightUp:
+                completeLaserStroke()
+            case .leftDown, .rightDown:
+                break
+            }
+        }
+
+        guard shouldShowPulse(for: event.kind) else { return }
 
         pulses.append(ClickPulse(
             kind: event.kind,
@@ -50,14 +76,97 @@ final class ClickOverlayView: NSView {
 
         let now = CACurrentMediaTime()
         pulses = pulses.filter { !$0.isExpired(at: now) }
+        completedLaserStrokes = completedLaserStrokes.filter { !$0.isExpired(at: now) }
 
+        drawLaser(at: now, in: context)
         for pulse in pulses {
             draw(pulse: pulse, at: now, in: context)
         }
 
-        if pulses.isEmpty {
+        if pulses.isEmpty && laserCursor?.isExpired(at: now) != false && activeLaserStroke == nil && completedLaserStrokes.isEmpty {
             stopDisplayLink()
         }
+    }
+
+    private func showLaserCursor(at point: CGPoint) {
+        laserCursor = LaserCursor(point: point, updatedAt: CACurrentMediaTime())
+        startDisplayLink()
+        needsDisplay = true
+    }
+
+    private func appendLaserPoint(_ point: CGPoint) {
+        let now = CACurrentMediaTime()
+        showLaserCursor(at: point)
+
+        if activeLaserStroke == nil {
+            activeLaserStroke = LaserStroke(points: [point], completedAt: nil)
+        } else if activeLaserStroke?.shouldAppend(point) == true {
+            activeLaserStroke?.points.append(point)
+        }
+
+        if activeLaserStroke?.points.count == 1 {
+            activeLaserStroke?.points.append(point)
+        }
+
+        laserCursor = LaserCursor(point: point, updatedAt: now)
+        startDisplayLink()
+        needsDisplay = true
+    }
+
+    private func completeLaserStroke() {
+        guard var stroke = activeLaserStroke else { return }
+        stroke.completedAt = CACurrentMediaTime()
+        completedLaserStrokes.append(stroke)
+        activeLaserStroke = nil
+        startDisplayLink()
+        needsDisplay = true
+    }
+
+    private func drawLaser(at now: CFTimeInterval, in context: CGContext) {
+        guard settings.showLaserPointer else { return }
+
+        for stroke in completedLaserStrokes {
+            drawLaserStroke(stroke, alpha: stroke.alpha(at: now), in: context)
+        }
+
+        if let activeLaserStroke {
+            drawLaserStroke(activeLaserStroke, alpha: 0.95, in: context)
+        }
+
+        guard let laserCursor, !laserCursor.isExpired(at: now) else { return }
+        let alpha = laserCursor.alpha(at: now)
+        let laserColor = NSColor(calibratedRed: 1.0, green: 0.16, blue: 0.24, alpha: 1)
+        context.saveGState()
+        context.setFillColor(laserColor.withAlphaComponent(alpha * 0.18).cgColor)
+        context.fillEllipse(in: CGRect(x: laserCursor.point.x - 14, y: laserCursor.point.y - 14, width: 28, height: 28))
+        context.setFillColor(laserColor.withAlphaComponent(alpha).cgColor)
+        context.fillEllipse(in: CGRect(x: laserCursor.point.x - 6, y: laserCursor.point.y - 6, width: 12, height: 12))
+        context.restoreGState()
+    }
+
+    private func drawLaserStroke(_ stroke: LaserStroke, alpha: CGFloat, in context: CGContext) {
+        guard stroke.points.count >= 2, alpha > 0 else { return }
+        let laserColor = NSColor(calibratedRed: 1.0, green: 0.16, blue: 0.24, alpha: 1)
+        context.saveGState()
+        context.setLineCap(.round)
+        context.setLineJoin(.round)
+
+        let path = CGMutablePath()
+        path.move(to: stroke.points[0])
+        for point in stroke.points.dropFirst() {
+            path.addLine(to: point)
+        }
+
+        context.addPath(path)
+        context.setStrokeColor(laserColor.withAlphaComponent(alpha * 0.2).cgColor)
+        context.setLineWidth(14)
+        context.strokePath()
+
+        context.addPath(path)
+        context.setStrokeColor(laserColor.withAlphaComponent(alpha).cgColor)
+        context.setLineWidth(5)
+        context.strokePath()
+        context.restoreGState()
     }
 
     private func draw(pulse: ClickPulse, at now: CFTimeInterval, in context: CGContext) {
@@ -153,6 +262,8 @@ final class ClickOverlayView: NSView {
                 color: pulse.color,
                 alpha: alpha * 0.78
             )
+        case .move:
+            break
         }
 
         context.restoreGState()
@@ -247,6 +358,8 @@ final class ClickOverlayView: NSView {
             return NSColor(calibratedRed: 1.0, green: 0.46, blue: 0.19, alpha: 1)
         case .drag:
             return NSColor(calibratedRed: 0.92, green: 0.84, blue: 0.22, alpha: 1)
+        case .move:
+            return .clear
         }
     }
 
@@ -254,6 +367,8 @@ final class ClickOverlayView: NSView {
         switch kind {
         case .drag:
             return min(0.38, settings.duration * 0.82)
+        case .move:
+            return 0
         case .leftUp, .rightUp:
             return settings.duration * 0.78
         case .leftDown, .rightDown:
@@ -265,6 +380,8 @@ final class ClickOverlayView: NSView {
         switch kind {
         case .drag:
             return settings.size * 0.6
+        case .move:
+            return 0
         case .leftUp, .rightUp:
             return settings.size * 0.82
         case .leftDown, .rightDown:
@@ -274,6 +391,21 @@ final class ClickOverlayView: NSView {
 
     private func clamp(_ value: CGFloat) -> CGFloat {
         max(0, min(1, value))
+    }
+
+    private func shouldShowPulse(for kind: ClickKind) -> Bool {
+        switch kind {
+        case .leftDown:
+            return settings.showPress
+        case .leftUp:
+            return settings.showRelease
+        case .rightDown, .rightUp:
+            return settings.showRightClick
+        case .drag:
+            return settings.showDrag && !settings.showLaserPointer
+        case .move:
+            return false
+        }
     }
 }
 
@@ -292,5 +424,44 @@ private struct ClickPulse {
 
     func isExpired(at time: CFTimeInterval) -> Bool {
         progress(at: time) >= 1
+    }
+}
+
+private struct LaserCursor {
+    static let fadeDuration: TimeInterval = 0.42
+
+    let point: CGPoint
+    let updatedAt: CFTimeInterval
+
+    func alpha(at time: CFTimeInterval) -> CGFloat {
+        let progress = CGFloat(max(0, min(1, (time - updatedAt) / Self.fadeDuration)))
+        return 1 - progress
+    }
+
+    func isExpired(at time: CFTimeInterval) -> Bool {
+        time - updatedAt >= Self.fadeDuration
+    }
+}
+
+private struct LaserStroke {
+    static let fadeDuration: TimeInterval = 0.9
+
+    var points: [CGPoint]
+    var completedAt: CFTimeInterval?
+
+    func shouldAppend(_ point: CGPoint) -> Bool {
+        guard let last = points.last else { return true }
+        return hypot(last.x - point.x, last.y - point.y) >= 2.5
+    }
+
+    func alpha(at time: CFTimeInterval) -> CGFloat {
+        guard let completedAt else { return 1 }
+        let progress = CGFloat(max(0, min(1, (time - completedAt) / Self.fadeDuration)))
+        return 1 - progress
+    }
+
+    func isExpired(at time: CFTimeInterval) -> Bool {
+        guard let completedAt else { return false }
+        return time - completedAt >= Self.fadeDuration
     }
 }

--- a/Sources/ClickLight/OverlayCoordinator.swift
+++ b/Sources/ClickLight/OverlayCoordinator.swift
@@ -28,7 +28,8 @@ final class OverlayCoordinator {
     }
 
     func show(_ event: ClickEvent) {
-        guard settings.isEnabled, shouldShow(event.kind) else { return }
+        guard settings.isEnabled else { return }
+        guard settings.showLaserPointer || shouldShow(event.kind) else { return }
         guard shouldAccept(event) else { return }
         guard let screen = screen(containing: event.location) else { return }
 
@@ -65,6 +66,8 @@ final class OverlayCoordinator {
             return settings.showRightClick
         case .drag:
             return settings.showDrag
+        case .move:
+            return false
         }
     }
 

--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -6,6 +6,7 @@ struct ClickSettings: Equatable {
     var showRelease: Bool
     var showRightClick: Bool
     var showDrag: Bool
+    var showLaserPointer: Bool
     var showMenuBarText: Bool
     var size: CGFloat
     var intensity: CGFloat
@@ -30,6 +31,7 @@ struct ClickSettings: Equatable {
         showRelease: true,
         showRightClick: true,
         showDrag: true,
+        showLaserPointer: false,
         showMenuBarText: false,
         size: 64,
         intensity: 0.7,
@@ -104,6 +106,7 @@ final class SettingsStore {
         static let showRelease = "showRelease"
         static let showRightClick = "showRightClick"
         static let showDrag = "showDrag"
+        static let showLaserPointer = "showLaserPointer"
         static let showMenuBarText = "showMenuBarText"
         static let size = "size"
         static let intensity = "intensity"
@@ -129,6 +132,7 @@ final class SettingsStore {
                 showRelease: defaults.bool(forKey: Key.showRelease),
                 showRightClick: defaults.bool(forKey: Key.showRightClick),
                 showDrag: defaults.bool(forKey: Key.showDrag),
+                showLaserPointer: defaults.bool(forKey: Key.showLaserPointer),
                 showMenuBarText: defaults.bool(forKey: Key.showMenuBarText),
                 size: CGFloat(defaults.double(forKey: Key.size)),
                 intensity: CGFloat(defaults.double(forKey: Key.intensity)),
@@ -145,6 +149,7 @@ final class SettingsStore {
             defaults.set(newValue.showRelease, forKey: Key.showRelease)
             defaults.set(newValue.showRightClick, forKey: Key.showRightClick)
             defaults.set(newValue.showDrag, forKey: Key.showDrag)
+            defaults.set(newValue.showLaserPointer, forKey: Key.showLaserPointer)
             defaults.set(newValue.showMenuBarText, forKey: Key.showMenuBarText)
             defaults.set(Double(newValue.size), forKey: Key.size)
             defaults.set(Double(newValue.intensity), forKey: Key.intensity)
@@ -171,6 +176,7 @@ final class SettingsStore {
             Key.showRelease: defaults.showRelease,
             Key.showRightClick: defaults.showRightClick,
             Key.showDrag: defaults.showDrag,
+            Key.showLaserPointer: defaults.showLaserPointer,
             Key.showMenuBarText: defaults.showMenuBarText,
             Key.size: Double(defaults.size),
             Key.intensity: Double(defaults.intensity),

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -76,6 +76,13 @@ final class StatusController {
         menu.addItem(NSMenuItem.separator())
 
         menu.addItem(toggleItem(
+            title: "Laser Pointer Mode",
+            isOn: settings.showLaserPointer,
+            action: #selector(toggleLaserPointer)
+        ))
+        menu.addItem(NSMenuItem.separator())
+
+        menu.addItem(toggleItem(
             title: "Show Press",
             isOn: settings.showPress,
             action: #selector(togglePress)
@@ -90,11 +97,13 @@ final class StatusController {
             isOn: settings.showRightClick,
             action: #selector(toggleRightClick)
         ))
-        menu.addItem(toggleItem(
+        let showDragItem = toggleItem(
             title: "Show Drag",
             isOn: settings.showDrag,
             action: #selector(toggleDrag)
-        ))
+        )
+        showDragItem.isEnabled = !settings.showLaserPointer
+        menu.addItem(showDragItem)
         menu.addItem(NSMenuItem.separator())
         menu.addItem(toggleItem(
             title: "Show Menu Bar Text",
@@ -239,6 +248,10 @@ final class StatusController {
 
     @objc private func toggleDrag() {
         settingsStore.update { $0.showDrag.toggle() }
+    }
+
+    @objc private func toggleLaserPointer() {
+        settingsStore.update { $0.showLaserPointer.toggle() }
     }
 
     @objc private func toggleMenuBarText() {


### PR DESCRIPTION
## What changed

- Add an opt-in **Laser Pointer Mode** toggle in the menu bar and Settings > Events.
- Show a fading red pointer while the cursor moves when laser mode is enabled.
- Draw temporary red freehand strokes while dragging, fading them after release.
- Replace the regular drag trail while laser mode is active so the visuals do not overlap.
- Track mouse-move events only while laser mode is enabled, leaving ordinary click highlighting behavior unchanged by default.
- Mention the optional laser drawing mode in the README feature list.

## Why

ClickLight already makes clicks visible during live demos. A laser mode lets a presenter point at something briefly or draw attention to an area without switching tools or leaving permanent annotations on screen.


https://github.com/user-attachments/assets/643063ab-cdf9-43f3-92a0-42a3dad70f48
