### PR TITLE
Add support for middle click events and settings toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ macOS menu-bar app that highlights mouse clicks for live demos and screen sharin
 ./build-app.sh
 
 # Iterate quickly after source changes
-./build-app.sh && pkill -x ClickLight; open ClickLight.app
+./build-app.sh && { pkill -x ClickLight || true; open ClickLight.app; }
 
 # Inspect UserDefaults during development
 defaults read com.aurorascharff.ClickLight
@@ -40,7 +40,7 @@ ClickEventTap (CGEventTap + NSEvent fallback)
 
 ## Key Conventions
 
-- **No async/await** — `@MainActor` throughout; use `DispatchQueue.main` if needed.
+- **UI mutations on the main actor** — keep AppKit and settings mutations on the main actor; event capture forwards UI work onto the main queue.
 - **Notifications for cross-component events** — settings changes and click events use `NotificationCenter`.
 - **Value types for data, classes for controllers** — `ClickEvent`, `ClickSettings`, `ClickKind` are structs/enums; controllers are classes.
 - **Settings access** — read via `settingsStore.settings.<property>`; write by replacing the whole struct: `settingsStore.settings = newSettings`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# ClickLight — Agent Instructions
+
+macOS menu-bar app that highlights mouse clicks for live demos and screen sharing. Native Swift/AppKit, no Xcode project required.
+
+## Build & Run
+
+```bash
+# Build the app bundle
+./build-app.sh
+
+# Iterate quickly after source changes
+./build-app.sh && pkill -x ClickLight; open ClickLight.app
+
+# Inspect UserDefaults during development
+defaults read com.aurorascharff.ClickLight
+```
+
+No test suite exists — verify behavior manually using **Menu Bar → Test Pulse at Pointer** and the Settings window. See [docs/LOCAL_DEVELOPMENT.md](docs/LOCAL_DEVELOPMENT.md) for full setup.
+
+## Architecture
+
+All UI state is `@MainActor`. Click events flow through a notification-based pipeline:
+
+```
+ClickEventTap (CGEventTap + NSEvent fallback)
+  → NotificationCenter didReceiveClickEvent
+  → AppDelegate (filters settings-window hits)
+  → OverlayCoordinator (per-screen ClickOverlayWindow)
+  → ClickOverlayView (CoreGraphics pulse/laser animation)
+```
+
+| Component | Responsibility |
+|-----------|---------------|
+| `ClickEventTap` | Global mouse capture; primary CGEventTap + NSEvent fallback |
+| `OverlayCoordinator` | One `ClickOverlayWindow` per screen; deduplicates events (3 px / 0.1 s) |
+| `ClickOverlayView` | CoreGraphics drawing; timer-driven animation loop |
+| `SettingsStore` | UserDefaults wrapper; posts `didChangeNotification` on write |
+| `StatusController` | Menu-bar NSStatusItem; throttled menu rebuild (0.1 s debounce) |
+| `AppDelegate` | Wires all components; handles screen change notifications |
+
+## Key Conventions
+
+- **No async/await** — `@MainActor` throughout; use `DispatchQueue.main` if needed.
+- **Notifications for cross-component events** — settings changes and click events use `NotificationCenter`.
+- **Value types for data, classes for controllers** — `ClickEvent`, `ClickSettings`, `ClickKind` are structs/enums; controllers are classes.
+- **Settings access** — read via `settingsStore.settings.<property>`; write by replacing the whole struct: `settingsStore.settings = newSettings`.
+- **Adding a new click kind** — update `ClickKind` enum, `ClickEventTap` mapping, `ClickLightSettingsView` toggle, and `ClickOverlayView` drawing logic.
+- **Adding a new setting** — add to `ClickSettings` struct with a default in `ClickSettings.defaults`; persist in `SettingsStore`.
+- **Overlay windows** — borderless, transparent, `ignoresMouseEvents = true`, `.screenSaver` level, `.canJoinAllSpaces`.
+- **No Xcode project** — build via `swift build` orchestrated by `build-app.sh`; version is read from the latest git tag.
+
+## Important Pitfalls
+
+- **Accessibility permission** is required for `CGEventTap`. After granting it in System Settings, the user must quit and reopen the app. Moving the `.app` bundle to a new path also requires re-granting.
+- **CoreGraphics drawing only** — `ClickOverlayView` uses raw `CGContext`; do not introduce `NSBezierPath` or layer-backed drawing.
+- **Laser pointer is CPU-intensive** — enabling it adds `mouseMoved` to the event filter; be careful adding more processing inside the move handler.
+- **Screen IDs are not stable across reboots** — `OverlayCoordinator` uses `NSScreenNumber` from `deviceDescription`, sufficient for runtime but not for persistence.
+- **Pulses in-flight keep old settings** — `refreshSettings()` applies immediately to new pulses; existing animations finish with their original parameters.
+
+## Releasing
+
+Tag-triggered GitHub Actions pipeline handles signing, notarization, Sparkle `appcast.xml`, and Homebrew cask update. Manual approval is required via the `release` environment. See [docs/RELEASING.md](docs/RELEASING.md).

--- a/Sources/ClickLight/ClickEvent.swift
+++ b/Sources/ClickLight/ClickEvent.swift
@@ -5,10 +5,12 @@ enum ClickKind: Sendable {
     case leftUp
     case rightDown
     case rightUp
+    case middleDown
+    case middleUp
     case drag
 
     var isRelease: Bool {
-        self == .leftUp || self == .rightUp
+        self == .leftUp || self == .rightUp || self == .middleUp
     }
 }
 

--- a/Sources/ClickLight/ClickEventTap.swift
+++ b/Sources/ClickLight/ClickEventTap.swift
@@ -38,6 +38,8 @@ final class ClickEventTap: ClickEventCapturing {
             CGEventType.leftMouseUp,
             CGEventType.rightMouseDown,
             CGEventType.rightMouseUp,
+            CGEventType.otherMouseDown,
+            CGEventType.otherMouseUp,
             CGEventType.leftMouseDragged,
             CGEventType.rightMouseDragged,
             CGEventType.otherMouseDragged
@@ -87,6 +89,8 @@ final class ClickEventTap: ClickEventCapturing {
             .leftMouseUp,
             .rightMouseDown,
             .rightMouseUp,
+            .otherMouseDown,
+            .otherMouseUp,
             .leftMouseDragged,
             .rightMouseDragged,
             .otherMouseDragged
@@ -111,7 +115,7 @@ final class ClickEventTap: ClickEventCapturing {
             return Unmanaged.passUnretained(event)
         }
 
-        guard let kind = ClickKind(type: type) else {
+        guard let kind = ClickKind(type: type, event: event) else {
             return Unmanaged.passUnretained(event)
         }
 
@@ -147,7 +151,7 @@ private func eventTapCallback(
 }
 
 private extension ClickKind {
-    init?(type: CGEventType) {
+    init?(type: CGEventType, event: CGEvent) {
         switch type {
         case .leftMouseDown:
             self = .leftDown
@@ -157,6 +161,10 @@ private extension ClickKind {
             self = .rightDown
         case .rightMouseUp:
             self = .rightUp
+        case .otherMouseDown where event.buttonNumber == 2:
+            self = .middleDown
+        case .otherMouseUp where event.buttonNumber == 2:
+            self = .middleUp
         case .leftMouseDragged, .rightMouseDragged, .otherMouseDragged:
             self = .drag
         default:
@@ -174,6 +182,10 @@ private extension ClickKind {
             self = .rightDown
         case .rightMouseUp:
             self = .rightUp
+        case .otherMouseDown where event.buttonNumber == 2:
+            self = .middleDown
+        case .otherMouseUp where event.buttonNumber == 2:
+            self = .middleUp
         case .leftMouseDragged, .rightMouseDragged, .otherMouseDragged:
             self = .drag
         default:
@@ -183,6 +195,10 @@ private extension ClickKind {
 }
 
 private extension CGEvent {
+    var buttonNumber: Int64 {
+        getIntegerValueField(.mouseEventButtonNumber)
+    }
+
     var timestampSeconds: TimeInterval {
         TimeInterval(timestamp) / 1_000_000_000
     }

--- a/Sources/ClickLight/ClickLightSettingsView.swift
+++ b/Sources/ClickLight/ClickLightSettingsView.swift
@@ -279,6 +279,14 @@ struct ClickLightSettingsView: View {
                         .accessibilityLabel("Show Right Click")
                 }
                 Divider().padding(.vertical, 6)
+                    ModernRow(title: "Show Middle Click",
+                          subtitle: "Highlight center-button clicks.") {
+                      Toggle("", isOn: binding(\.showMiddleClick))
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .accessibilityLabel("Show Middle Click")
+                    }
+                    Divider().padding(.vertical, 6)
                 ModernRow(title: "Show Drag",
                           subtitle: "Trail pointer movement while dragging.") {
                     Toggle("", isOn: binding(\.showDrag))

--- a/Sources/ClickLight/ClickOverlayView.swift
+++ b/Sources/ClickLight/ClickOverlayView.swift
@@ -145,6 +145,34 @@ final class ClickOverlayView: NSView {
                 alpha: releaseAlpha
             )
             drawCrosshair(context: context, point: pulse.point, size: pulse.baseSize * (0.16 + 0.08 * fade), color: pulse.color, alpha: releaseAlpha * 0.7)
+        case .middleDown:
+            drawGlowIfNeeded(
+                context: context,
+                point: pulse.point,
+                radius: pulse.baseSize * (0.26 + 0.68 * eased),
+                color: pulse.color,
+                alpha: fade * visualIntensity
+            )
+            drawRing(
+                context: context,
+                point: pulse.point,
+                radius: pulse.baseSize * (0.16 + 0.52 * eased),
+                lineWidth: lineWidth,
+                color: pulse.color,
+                alpha: alpha
+            )
+            drawDiamond(context: context, point: pulse.point, size: pulse.baseSize * 0.24, color: pulse.color, alpha: alpha * 0.86)
+        case .middleUp:
+            let releaseSize = pulse.baseSize * (0.32 - 0.12 * eased)
+            let releaseAlpha = alpha * 0.5
+            drawGlowIfNeeded(
+                context: context,
+                point: pulse.point,
+                radius: pulse.baseSize * (0.42 - 0.12 * eased),
+                color: pulse.color,
+                alpha: fade * visualIntensity * 0.38
+            )
+            drawDiamond(context: context, point: pulse.point, size: releaseSize, color: pulse.color, alpha: releaseAlpha * 0.82)
         case .drag:
             drawDot(
                 context: context,
@@ -214,6 +242,16 @@ final class ClickOverlayView: NSView {
         context.strokePath()
     }
 
+    private func drawDiamond(context: CGContext, point: CGPoint, size: CGFloat, color: NSColor, alpha: CGFloat) {
+        context.setFillColor(color.withAlphaComponent(alpha).cgColor)
+        context.move(to: CGPoint(x: point.x, y: point.y + size))
+        context.addLine(to: CGPoint(x: point.x + size, y: point.y))
+        context.addLine(to: CGPoint(x: point.x, y: point.y - size))
+        context.addLine(to: CGPoint(x: point.x - size, y: point.y))
+        context.closePath()
+        context.fillPath()
+    }
+
     private func startDisplayLink() {
         guard displayLink == nil else { return }
         displayLink = Timer(timeInterval: 1.0 / 60.0, target: self, selector: #selector(displayLinkDidTick), userInfo: nil, repeats: true)
@@ -245,6 +283,8 @@ final class ClickOverlayView: NSView {
             return NSColor(calibratedRed: 0.4, green: 0.88, blue: 1.0, alpha: 1)
         case .rightDown, .rightUp:
             return NSColor(calibratedRed: 1.0, green: 0.46, blue: 0.19, alpha: 1)
+        case .middleDown, .middleUp:
+            return NSColor(calibratedRed: 0.27, green: 0.92, blue: 0.58, alpha: 1)
         case .drag:
             return NSColor(calibratedRed: 0.92, green: 0.84, blue: 0.22, alpha: 1)
         }
@@ -254,9 +294,9 @@ final class ClickOverlayView: NSView {
         switch kind {
         case .drag:
             return min(0.38, settings.duration * 0.82)
-        case .leftUp, .rightUp:
+        case .leftUp, .rightUp, .middleUp:
             return settings.duration * 0.78
-        case .leftDown, .rightDown:
+        case .leftDown, .rightDown, .middleDown:
             return settings.duration
         }
     }
@@ -265,9 +305,9 @@ final class ClickOverlayView: NSView {
         switch kind {
         case .drag:
             return settings.size * 0.6
-        case .leftUp, .rightUp:
+        case .leftUp, .rightUp, .middleUp:
             return settings.size * 0.82
-        case .leftDown, .rightDown:
+        case .leftDown, .rightDown, .middleDown:
             return settings.size
         }
     }

--- a/Sources/ClickLight/ClickOverlayView.swift
+++ b/Sources/ClickLight/ClickOverlayView.swift
@@ -439,10 +439,14 @@ final class ClickOverlayView: NSView {
             return settings.showPress
         case .leftUp:
             return settings.showRelease
-        case .rightDown, .rightUp:
+        case .rightDown:
             return settings.showRightClick
-        case .middleDown, .middleUp:
+        case .rightUp:
+            return settings.showRightClick && settings.showRelease
+        case .middleDown:
             return settings.showMiddleClick
+        case .middleUp:
+            return settings.showMiddleClick && settings.showRelease
         case .drag:
             return settings.showDrag && !settings.showLaserPointer
         case .move:

--- a/Sources/ClickLight/ClickOverlayView.swift
+++ b/Sources/ClickLight/ClickOverlayView.swift
@@ -47,9 +47,9 @@ final class ClickOverlayView: NSView {
             case .drag:
                 appendLaserPoint(localPoint)
                 return
-            case .leftUp, .rightUp:
+            case .leftUp, .rightUp, .middleUp:
                 completeLaserStroke()
-            case .leftDown, .rightDown:
+            case .leftDown, .rightDown, .middleDown:
                 break
             }
         }
@@ -441,6 +441,8 @@ final class ClickOverlayView: NSView {
             return settings.showRelease
         case .rightDown, .rightUp:
             return settings.showRightClick
+        case .middleDown, .middleUp:
+            return settings.showMiddleClick
         case .drag:
             return settings.showDrag && !settings.showLaserPointer
         case .move:

--- a/Sources/ClickLight/OverlayCoordinator.swift
+++ b/Sources/ClickLight/OverlayCoordinator.swift
@@ -63,6 +63,8 @@ final class OverlayCoordinator {
             return settings.showRelease
         case .rightDown, .rightUp:
             return settings.showRightClick
+        case .middleDown, .middleUp:
+            return settings.showMiddleClick
         case .drag:
             return settings.showDrag
         }

--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -5,6 +5,7 @@ struct ClickSettings: Equatable {
     var showPress: Bool
     var showRelease: Bool
     var showRightClick: Bool
+    var showMiddleClick: Bool
     var showDrag: Bool
     var showMenuBarText: Bool
     var size: CGFloat
@@ -29,6 +30,7 @@ struct ClickSettings: Equatable {
         showPress: true,
         showRelease: true,
         showRightClick: true,
+        showMiddleClick: true,
         showDrag: true,
         showMenuBarText: false,
         size: 64,
@@ -103,6 +105,7 @@ final class SettingsStore {
         static let showPress = "showPress"
         static let showRelease = "showRelease"
         static let showRightClick = "showRightClick"
+        static let showMiddleClick = "showMiddleClick"
         static let showDrag = "showDrag"
         static let showMenuBarText = "showMenuBarText"
         static let size = "size"
@@ -128,6 +131,7 @@ final class SettingsStore {
                 showPress: defaults.bool(forKey: Key.showPress),
                 showRelease: defaults.bool(forKey: Key.showRelease),
                 showRightClick: defaults.bool(forKey: Key.showRightClick),
+                showMiddleClick: defaults.bool(forKey: Key.showMiddleClick),
                 showDrag: defaults.bool(forKey: Key.showDrag),
                 showMenuBarText: defaults.bool(forKey: Key.showMenuBarText),
                 size: CGFloat(defaults.double(forKey: Key.size)),
@@ -144,6 +148,7 @@ final class SettingsStore {
             defaults.set(newValue.showPress, forKey: Key.showPress)
             defaults.set(newValue.showRelease, forKey: Key.showRelease)
             defaults.set(newValue.showRightClick, forKey: Key.showRightClick)
+            defaults.set(newValue.showMiddleClick, forKey: Key.showMiddleClick)
             defaults.set(newValue.showDrag, forKey: Key.showDrag)
             defaults.set(newValue.showMenuBarText, forKey: Key.showMenuBarText)
             defaults.set(Double(newValue.size), forKey: Key.size)
@@ -170,6 +175,7 @@ final class SettingsStore {
             Key.showPress: defaults.showPress,
             Key.showRelease: defaults.showRelease,
             Key.showRightClick: defaults.showRightClick,
+            Key.showMiddleClick: defaults.showMiddleClick,
             Key.showDrag: defaults.showDrag,
             Key.showMenuBarText: defaults.showMenuBarText,
             Key.size: Double(defaults.size),

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -91,6 +91,11 @@ final class StatusController {
             action: #selector(toggleRightClick)
         ))
         menu.addItem(toggleItem(
+            title: "Show Middle Click",
+            isOn: settings.showMiddleClick,
+            action: #selector(toggleMiddleClick)
+        ))
+        menu.addItem(toggleItem(
             title: "Show Drag",
             isOn: settings.showDrag,
             action: #selector(toggleDrag)
@@ -235,6 +240,10 @@ final class StatusController {
 
     @objc private func toggleRightClick() {
         settingsStore.update { $0.showRightClick.toggle() }
+    }
+
+    @objc private func toggleMiddleClick() {
+        settingsStore.update { $0.showMiddleClick.toggle() }
     }
 
     @objc private func toggleDrag() {


### PR DESCRIPTION
Introduce support for middle click events, including the ability to toggle their visibility in settings. This enhancement allows users to highlight middle-button clicks in the interface.

I have an MX mouse and i have a center click on it, nice little touch.

Also fixes #22 

https://github.com/user-attachments/assets/6f83b7b5-1889-4b91-9b99-afb0ea12fd9f


