### PR TITLE
Implement main menu with quit functionality in AppDelegate

### DIFF
--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -24,6 +24,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var laserPointerEnabledState: Bool?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        configureMainMenu()
         overlayCoordinator.start()
         permissions.requestAccessibilityIfNeeded()
         captureEnabledState = settingsStore.settings.isEnabled
@@ -72,6 +73,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             location: NSEvent.mouseLocation,
             timestamp: CACurrentMediaTime()
         ))
+    }
+
+    private func configureMainMenu() {
+        let mainMenu = NSMenu()
+        let appMenuItem = NSMenuItem()
+        let appMenu = NSMenu(title: "ClickLight")
+
+        let quitItem = NSMenuItem(
+            title: "Quit ClickLight",
+            action: #selector(handleQuitShortcut),
+            keyEquivalent: "q"
+        )
+        quitItem.target = self
+        appMenu.addItem(quitItem)
+
+        appMenuItem.submenu = appMenu
+        mainMenu.addItem(appMenuItem)
+        NSApp.mainMenu = mainMenu
+    }
+
+    @objc private func handleQuitShortcut() {
+        if settingsWindowController?.window?.isVisible == true {
+            settingsWindowController?.close()
+            return
+        }
+
+        NSApp.terminate(nil)
     }
 
     private func openSettings() {

--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -94,11 +94,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func handleQuitShortcut() {
-        if settingsWindowController?.window?.isVisible == true {
-            settingsWindowController?.close()
-            return
-        }
-
         NSApp.terminate(nil)
     }
 


### PR DESCRIPTION
Fixes #20

Add a main menu to the application that includes a "Quit ClickLight" option, allowing users to exit the application using the Command-Q shortcut. This enhances user experience by providing a standard way to close the app.