### PR TITLE
Add primary color option to ClickColorPreset enum

### DIFF
--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -45,18 +45,21 @@ struct ClickSettings: Equatable {
 
 enum ClickColorPreset: String, CaseIterable, Equatable {
     case `default`
-    case custom
+    case primary
     case blue
     case green
     case purple
     case pink
     case orange
     case white
+    case custom
 
     var title: String {
         switch self {
         case .default:
             return "Default"
+        case .primary:
+            return "Primary"
         case .custom:
             return "Custom"
         case .blue:
@@ -78,6 +81,8 @@ enum ClickColorPreset: String, CaseIterable, Equatable {
         switch self {
         case .default:
             return nil
+        case .primary:
+            return NSColor.controlAccentColor
         case .custom:
             return nil
         case .blue:


### PR DESCRIPTION
Introduce a new primary color option in the ClickColorPreset enum, enhancing color selection capabilities.

Fixes #16


https://github.com/user-attachments/assets/ca136f41-fdb9-49c1-9b49-7ac21c950c5f


