### PR TITLE
Implement custom color mode for ClickLight settings

### DIFF
--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -44,10 +44,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             name: ClickEventTap.didReceiveClickEvent,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidBecomeActive),
+            name: NSApplication.didBecomeActiveNotification,
+            object: nil
+        )
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         captureController.stop()
+    }
+
+    @objc private func appDidBecomeActive() {
+        launchAtLogin.refresh()
+        statusController.refresh()
     }
 
     @objc private func settingsDidChange() {

--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -56,7 +56,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func appDidBecomeActive() {
-        launchAtLogin.refresh()
         statusController.refresh()
     }
 

--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -14,7 +14,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         onCheckForUpdates: { UpdateChecker.shared.checkForUpdates() },
         updatesAreConfigured: { UpdateChecker.shared.isConfigured },
         onOpenSettings: { [weak self] in self?.openSettings() },
-        onTestPulse: { [weak self] in self?.showTestPulse() },
         onQuit: { NSApplication.shared.terminate(nil) }
     )
     private let eventTap = ClickEventTap()
@@ -78,14 +77,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         overlayCoordinator.show(box.event)
     }
 
-    private func showTestPulse() {
-        overlayCoordinator.show(ClickEvent(
-            kind: .leftDown,
-            location: NSEvent.mouseLocation,
-            timestamp: CACurrentMediaTime()
-        ))
-    }
-
     private func configureMainMenu() {
         let mainMenu = NSMenu()
         let appMenuItem = NSMenuItem()
@@ -112,8 +103,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let controller = settingsWindowController ?? SettingsWindowController(
             settingsStore: settingsStore,
             launchAtLogin: launchAtLogin,
-            permissions: permissions,
-            onTestPulse: { [weak self] in self?.showTestPulse() }
+            permissions: permissions
         )
         settingsWindowController = controller
         controller.show()

--- a/Sources/ClickLight/ClickLightSettingsView.swift
+++ b/Sources/ClickLight/ClickLightSettingsView.swift
@@ -52,6 +52,35 @@ struct ClickLightSettingsView: View {
         .navigationSplitViewStyle(.balanced)
     }
 
+    @ViewBuilder
+    private func customColorRow(title: String, subtitle: String, color: Binding<Color>) -> some View {
+        ModernRow(title: title, subtitle: subtitle) {
+            ColorPicker(
+                "",
+                selection: color,
+                supportsOpacity: false
+            )
+            .labelsHidden()
+            .accessibilityLabel(title)
+        }
+    }
+
+    private func customClickColorBinding(_ target: CustomClickColorTarget) -> Binding<Color> {
+        Binding(
+            get: {
+                switch target {
+                case .left:
+                    return Color(nsColor: viewModel.settings.customLeftColor)
+                case .right:
+                    return Color(nsColor: viewModel.settings.customRightColor)
+                case .drag:
+                    return Color(nsColor: viewModel.settings.customDragColor)
+                }
+            },
+            set: { viewModel.applyCustomColor(NSColor($0), to: target) }
+        )
+    }
+
     // MARK: - Pane Header
 
     private var paneHeader: some View {
@@ -232,20 +261,64 @@ struct ClickLightSettingsView: View {
                         .pickerStyle(.menu)
                     }
 
-                    Divider()
+                    if viewModel.settings.colorPreset == .custom {
+                        Divider()
 
-                    ModernRow(title: "Custom Color",
-                              subtitle: "Picking a color switches to Custom automatically.") {
-                        ColorPicker(
-                            "",
-                            selection: Binding(
-                                get: { resolvedColor },
-                                set: { viewModel.applyCustomColor(NSColor($0)) }
-                            ),
-                            supportsOpacity: false
-                        )
+                        Picker("Custom Color Mode", selection: binding(\.customColorMode)) {
+                            ForEach(CustomClickColorMode.allCases, id: \.rawValue) { mode in
+                                Text(mode.title).tag(mode)
+                            }
+                        }
                         .labelsHidden()
-                        .accessibilityLabel("Custom Color Picker")
+                        .pickerStyle(.segmented)
+                        .accessibilityLabel("Custom Color Mode")
+
+                        if viewModel.settings.customColorMode == .all {
+                            customColorRow(
+                                title: "Custom Color",
+                                subtitle: "Use one custom color for every click.",
+                                color: Binding(
+                                    get: { Color(nsColor: viewModel.settings.customColor) },
+                                    set: { viewModel.applyCustomColor(NSColor($0)) }
+                                )
+                            )
+                        } else {
+                            VStack(spacing: 0) {
+                                customColorRow(
+                                    title: "Left Click",
+                                    subtitle: "Used for left press and release pulses.",
+                                    color: customClickColorBinding(.left)
+                                )
+                                Divider().padding(.vertical, 6)
+                                customColorRow(
+                                    title: "Right Click",
+                                    subtitle: "Used for secondary-button pulses.",
+                                    color: customClickColorBinding(.right)
+                                )
+                                Divider().padding(.vertical, 6)
+                                customColorRow(
+                                    title: "Drag",
+                                    subtitle: "Used for the normal drag trail.",
+                                    color: customClickColorBinding(.drag)
+                                )
+                            }
+                        }
+                    } else {
+                        Divider()
+
+                        ModernRow(title: "Custom Color",
+                                  subtitle: "Picking a color switches to Custom automatically.") {
+                            ColorPicker(
+                                "",
+                                selection: Binding(
+                                    get: { resolvedColor },
+                                    set: { viewModel.applyCustomColor(NSColor($0)) }
+                                ),
+                                supportsOpacity: false
+                            )
+                            .labelsHidden()
+                            .accessibilityLabel("Custom Color Picker")
+                        }
                     }
                 }
             }

--- a/Sources/ClickLight/ClickLightSettingsView.swift
+++ b/Sources/ClickLight/ClickLightSettingsView.swift
@@ -73,6 +73,8 @@ struct ClickLightSettingsView: View {
                     return Color(nsColor: viewModel.settings.customLeftColor)
                 case .right:
                     return Color(nsColor: viewModel.settings.customRightColor)
+                case .middle:
+                    return Color(nsColor: viewModel.settings.customMiddleColor)
                 case .drag:
                     return Color(nsColor: viewModel.settings.customDragColor)
                 }
@@ -294,6 +296,12 @@ struct ClickLightSettingsView: View {
                                     title: "Right Click",
                                     subtitle: "Used for secondary-button pulses.",
                                     color: customClickColorBinding(.right)
+                                )
+                                Divider().padding(.vertical, 6)
+                                customColorRow(
+                                    title: "Middle Click",
+                                    subtitle: "Used for center-button pulses.",
+                                    color: customClickColorBinding(.middle)
                                 )
                                 Divider().padding(.vertical, 6)
                                 customColorRow(

--- a/Sources/ClickLight/ClickLightSettingsView.swift
+++ b/Sources/ClickLight/ClickLightSettingsView.swift
@@ -8,19 +8,34 @@ struct ClickLightSettingsView: View {
 
     var body: some View {
         NavigationSplitView {
-            List(SettingsPane.allCases, id: \.self, selection: $selectedPane) { pane in
-                Label {
-                    Text(pane.title)
-                        .font(.system(size: 13, weight: .medium))
-                } icon: {
-                    Image(systemName: pane.icon)
-                        .symbolRenderingMode(.monochrome)
-                        .foregroundStyle(.primary)
+            VStack(spacing: 0) {
+                List(SettingsPane.allCases, id: \.self, selection: $selectedPane) { pane in
+                    Label {
+                        Text(pane.title)
+                            .font(.system(size: 13, weight: .medium))
+                    } icon: {
+                        Image(systemName: pane.icon)
+                            .symbolRenderingMode(.monochrome)
+                            .foregroundStyle(.primary)
+                    }
+                    .padding(.vertical, 2)
+                    .tag(pane)
                 }
-                .padding(.vertical, 2)
-                .tag(pane)
+                .listStyle(.sidebar)
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("Preview Pad", systemImage: "cursorarrow.click.2")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+
+                    ClickPreviewPad(settings: viewModel.settings)
+                        .frame(height: 116)
+                        .accessibilityLabel("Preview Pad")
+                }
+                .padding(12)
             }
-            .listStyle(.sidebar)
             .navigationSplitViewColumnWidth(min: 180, ideal: 200, max: 240)
         } detail: {
             ScrollView {
@@ -156,18 +171,6 @@ struct ClickLightSettingsView: View {
 
     private var stylePane: some View {
         VStack(spacing: 16) {
-            SettingsCard {
-                ModernRow(title: "Preview",
-                          subtitle: "Show the current pulse style at the pointer.") {
-                    Button {
-                        viewModel.previewPulse()
-                    } label: {
-                        Label("Preview Pulse", systemImage: "cursorarrow.click.2")
-                    }
-                    .controlSize(.regular)
-                }
-            }
-
             SettingsCard(title: "Size", subtitle: "How large the click pulse appears.") {
                 VStack(alignment: .leading, spacing: 16) {
                     presetSegmented(
@@ -615,6 +618,112 @@ private struct ColorSwatch: View {
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
                     .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1)
             )
+    }
+}
+
+private struct ClickPreviewPad: NSViewRepresentable {
+    let settings: ClickSettings
+
+    func makeNSView(context: Context) -> InteractiveClickPreviewView {
+        InteractiveClickPreviewView(settings: settings)
+    }
+
+    func updateNSView(_ nsView: InteractiveClickPreviewView, context: Context) {
+        nsView.apply(settings: settings)
+    }
+}
+
+private final class InteractiveClickPreviewView: NSView {
+    private let overlayView: ClickOverlayView
+    private var settings: ClickSettings
+
+    init(settings: ClickSettings) {
+        self.settings = settings
+        self.overlayView = ClickOverlayView(
+            screenFrame: CGRect(x: 0, y: 0, width: 200, height: 116),
+            settings: settings
+        )
+        super.init(frame: .zero)
+
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+        layer?.cornerRadius = 8
+        layer?.masksToBounds = true
+        layer?.borderWidth = 1
+        layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.55).cgColor
+
+        overlayView.autoresizingMask = [.width, .height]
+        addSubview(overlayView)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func layout() {
+        super.layout()
+        overlayView.frame = bounds
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        bounds.contains(point) ? self : nil
+    }
+
+    func apply(settings: ClickSettings) {
+        self.settings = settings
+        overlayView.apply(settings: settings)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        show(.leftDown, event: event)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        show(.leftUp, event: event)
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        show(.rightDown, event: event)
+    }
+
+    override func rightMouseUp(with event: NSEvent) {
+        show(.rightUp, event: event)
+    }
+
+    override func otherMouseDown(with event: NSEvent) {
+        guard event.buttonNumber == 2 else { return }
+        show(.middleDown, event: event)
+    }
+
+    override func otherMouseUp(with event: NSEvent) {
+        guard event.buttonNumber == 2 else { return }
+        show(.middleUp, event: event)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        show(.drag, event: event)
+    }
+
+    override func rightMouseDragged(with event: NSEvent) {
+        show(.drag, event: event)
+    }
+
+    override func otherMouseDragged(with event: NSEvent) {
+        guard event.buttonNumber == 2 else { return }
+        show(.drag, event: event)
+    }
+
+    private func show(_ kind: ClickKind, event: NSEvent) {
+        guard settings.isEnabled else { return }
+        let location = convert(event.locationInWindow, from: nil)
+        overlayView.show(
+            event: ClickEvent(
+                kind: kind,
+                location: location,
+                timestamp: CACurrentMediaTime()
+            ),
+            settings: settings
+        )
     }
 }
 

--- a/Sources/ClickLight/ClickOverlayView.swift
+++ b/Sources/ClickLight/ClickOverlayView.swift
@@ -389,6 +389,8 @@ final class ClickOverlayView: NSView {
                     return settings.customLeftColor
                 case .rightDown, .rightUp:
                     return settings.customRightColor
+                case .middleDown, .middleUp:
+                    return settings.customMiddleColor
                 case .drag:
                     return settings.customDragColor
                 case .move:

--- a/Sources/ClickLight/ClickOverlayView.swift
+++ b/Sources/ClickLight/ClickOverlayView.swift
@@ -342,7 +342,21 @@ final class ClickOverlayView: NSView {
 
     private func color(for kind: ClickKind) -> NSColor {
         if settings.colorPreset == .custom {
-            return settings.customColor
+            switch settings.customColorMode {
+            case .all:
+                return settings.customColor
+            case .byClick:
+                switch kind {
+                case .leftDown, .leftUp:
+                    return settings.customLeftColor
+                case .rightDown, .rightUp:
+                    return settings.customRightColor
+                case .drag:
+                    return settings.customDragColor
+                case .move:
+                    return .clear
+                }
+            }
         }
 
         if let color = settings.colorPreset.color {

--- a/Sources/ClickLight/LaunchAtLoginController.swift
+++ b/Sources/ClickLight/LaunchAtLoginController.swift
@@ -5,6 +5,7 @@ import ServiceManagement
 protocol LaunchAtLoginManaging {
     var isEnabled: Bool { get }
     func setEnabled(_ enabled: Bool) throws
+    func refresh()
 }
 
 enum LaunchAtLoginState {
@@ -27,6 +28,10 @@ final class LaunchAtLoginController: LaunchAtLoginManaging {
         } else {
             try SMAppService.mainApp.unregister()
         }
-        cachedIsEnabled = enabled
+        refresh()
+    }
+
+    func refresh() {
+        cachedIsEnabled = SMAppService.mainApp.status == .enabled
     }
 }

--- a/Sources/ClickLight/LaunchAtLoginController.swift
+++ b/Sources/ClickLight/LaunchAtLoginController.swift
@@ -15,8 +15,10 @@ enum LaunchAtLoginState {
 
 @MainActor
 final class LaunchAtLoginController: LaunchAtLoginManaging {
+    private var cachedIsEnabled = SMAppService.mainApp.status == .enabled
+
     var isEnabled: Bool {
-        SMAppService.mainApp.status == .enabled
+        cachedIsEnabled
     }
 
     func setEnabled(_ enabled: Bool) throws {
@@ -25,5 +27,6 @@ final class LaunchAtLoginController: LaunchAtLoginManaging {
         } else {
             try SMAppService.mainApp.unregister()
         }
+        cachedIsEnabled = enabled
     }
 }

--- a/Sources/ClickLight/LaunchAtLoginController.swift
+++ b/Sources/ClickLight/LaunchAtLoginController.swift
@@ -5,7 +5,6 @@ import ServiceManagement
 protocol LaunchAtLoginManaging {
     var isEnabled: Bool { get }
     func setEnabled(_ enabled: Bool) throws
-    func refresh()
 }
 
 enum LaunchAtLoginState {
@@ -16,10 +15,8 @@ enum LaunchAtLoginState {
 
 @MainActor
 final class LaunchAtLoginController: LaunchAtLoginManaging {
-    private var cachedIsEnabled = SMAppService.mainApp.status == .enabled
-
     var isEnabled: Bool {
-        cachedIsEnabled
+        SMAppService.mainApp.status == .enabled
     }
 
     func setEnabled(_ enabled: Bool) throws {
@@ -28,10 +25,5 @@ final class LaunchAtLoginController: LaunchAtLoginManaging {
         } else {
             try SMAppService.mainApp.unregister()
         }
-        refresh()
-    }
-
-    func refresh() {
-        cachedIsEnabled = SMAppService.mainApp.status == .enabled
     }
 }

--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -12,15 +12,52 @@ struct ClickSettings: Equatable {
     var intensity: CGFloat
     var duration: TimeInterval
     var colorPreset: ClickColorPreset
+    var customColorMode: CustomClickColorMode
     var customColorRed: CGFloat
     var customColorGreen: CGFloat
     var customColorBlue: CGFloat
+    var customLeftColorRed: CGFloat
+    var customLeftColorGreen: CGFloat
+    var customLeftColorBlue: CGFloat
+    var customRightColorRed: CGFloat
+    var customRightColorGreen: CGFloat
+    var customRightColorBlue: CGFloat
+    var customDragColorRed: CGFloat
+    var customDragColorGreen: CGFloat
+    var customDragColorBlue: CGFloat
 
     var customColor: NSColor {
         NSColor(
             calibratedRed: customColorRed.sanitizedColorComponent,
             green: customColorGreen.sanitizedColorComponent,
             blue: customColorBlue.sanitizedColorComponent,
+            alpha: 1
+        )
+    }
+
+    var customLeftColor: NSColor {
+        NSColor(
+            calibratedRed: customLeftColorRed.sanitizedColorComponent,
+            green: customLeftColorGreen.sanitizedColorComponent,
+            blue: customLeftColorBlue.sanitizedColorComponent,
+            alpha: 1
+        )
+    }
+
+    var customRightColor: NSColor {
+        NSColor(
+            calibratedRed: customRightColorRed.sanitizedColorComponent,
+            green: customRightColorGreen.sanitizedColorComponent,
+            blue: customRightColorBlue.sanitizedColorComponent,
+            alpha: 1
+        )
+    }
+
+    var customDragColor: NSColor {
+        NSColor(
+            calibratedRed: customDragColorRed.sanitizedColorComponent,
+            green: customDragColorGreen.sanitizedColorComponent,
+            blue: customDragColorBlue.sanitizedColorComponent,
             alpha: 1
         )
     }
@@ -37,10 +74,40 @@ struct ClickSettings: Equatable {
         intensity: 0.7,
         duration: 0.48,
         colorPreset: .default,
+        customColorMode: .all,
         customColorRed: 0.0,
         customColorGreen: 0.74,
-        customColorBlue: 1.0
+        customColorBlue: 1.0,
+        customLeftColorRed: 0.0,
+        customLeftColorGreen: 0.74,
+        customLeftColorBlue: 1.0,
+        customRightColorRed: 1.0,
+        customRightColorGreen: 0.46,
+        customRightColorBlue: 0.19,
+        customDragColorRed: 0.92,
+        customDragColorGreen: 0.84,
+        customDragColorBlue: 0.22
     )
+}
+
+enum CustomClickColorMode: String, CaseIterable, Equatable {
+    case all
+    case byClick
+
+    var title: String {
+        switch self {
+        case .all:
+            return "One Color"
+        case .byClick:
+            return "By Click"
+        }
+    }
+}
+
+enum CustomClickColorTarget {
+    case left
+    case right
+    case drag
 }
 
 enum ClickColorPreset: String, CaseIterable, Equatable {
@@ -112,9 +179,19 @@ final class SettingsStore {
         static let intensity = "intensity"
         static let duration = "duration"
         static let colorPreset = "colorPreset"
+        static let customColorMode = "customColorMode"
         static let customColorRed = "customColorRed"
         static let customColorGreen = "customColorGreen"
         static let customColorBlue = "customColorBlue"
+        static let customLeftColorRed = "customLeftColorRed"
+        static let customLeftColorGreen = "customLeftColorGreen"
+        static let customLeftColorBlue = "customLeftColorBlue"
+        static let customRightColorRed = "customRightColorRed"
+        static let customRightColorGreen = "customRightColorGreen"
+        static let customRightColorBlue = "customRightColorBlue"
+        static let customDragColorRed = "customDragColorRed"
+        static let customDragColorGreen = "customDragColorGreen"
+        static let customDragColorBlue = "customDragColorBlue"
     }
 
     private let defaults: UserDefaults
@@ -138,9 +215,19 @@ final class SettingsStore {
                 intensity: CGFloat(defaults.double(forKey: Key.intensity)),
                 duration: defaults.double(forKey: Key.duration),
                 colorPreset: ClickColorPreset(rawValue: defaults.string(forKey: Key.colorPreset) ?? "") ?? .default,
+                customColorMode: CustomClickColorMode(rawValue: defaults.string(forKey: Key.customColorMode) ?? "") ?? .all,
                 customColorRed: CGFloat(defaults.double(forKey: Key.customColorRed)).sanitizedColorComponent,
                 customColorGreen: CGFloat(defaults.double(forKey: Key.customColorGreen)).sanitizedColorComponent,
-                customColorBlue: CGFloat(defaults.double(forKey: Key.customColorBlue)).sanitizedColorComponent
+                customColorBlue: CGFloat(defaults.double(forKey: Key.customColorBlue)).sanitizedColorComponent,
+                customLeftColorRed: CGFloat(defaults.double(forKey: Key.customLeftColorRed)).sanitizedColorComponent,
+                customLeftColorGreen: CGFloat(defaults.double(forKey: Key.customLeftColorGreen)).sanitizedColorComponent,
+                customLeftColorBlue: CGFloat(defaults.double(forKey: Key.customLeftColorBlue)).sanitizedColorComponent,
+                customRightColorRed: CGFloat(defaults.double(forKey: Key.customRightColorRed)).sanitizedColorComponent,
+                customRightColorGreen: CGFloat(defaults.double(forKey: Key.customRightColorGreen)).sanitizedColorComponent,
+                customRightColorBlue: CGFloat(defaults.double(forKey: Key.customRightColorBlue)).sanitizedColorComponent,
+                customDragColorRed: CGFloat(defaults.double(forKey: Key.customDragColorRed)).sanitizedColorComponent,
+                customDragColorGreen: CGFloat(defaults.double(forKey: Key.customDragColorGreen)).sanitizedColorComponent,
+                customDragColorBlue: CGFloat(defaults.double(forKey: Key.customDragColorBlue)).sanitizedColorComponent
             )
         }
         set {
@@ -155,9 +242,19 @@ final class SettingsStore {
             defaults.set(Double(newValue.intensity), forKey: Key.intensity)
             defaults.set(newValue.duration, forKey: Key.duration)
             defaults.set(newValue.colorPreset.rawValue, forKey: Key.colorPreset)
+            defaults.set(newValue.customColorMode.rawValue, forKey: Key.customColorMode)
             defaults.set(Double(newValue.customColorRed), forKey: Key.customColorRed)
             defaults.set(Double(newValue.customColorGreen), forKey: Key.customColorGreen)
             defaults.set(Double(newValue.customColorBlue), forKey: Key.customColorBlue)
+            defaults.set(Double(newValue.customLeftColorRed), forKey: Key.customLeftColorRed)
+            defaults.set(Double(newValue.customLeftColorGreen), forKey: Key.customLeftColorGreen)
+            defaults.set(Double(newValue.customLeftColorBlue), forKey: Key.customLeftColorBlue)
+            defaults.set(Double(newValue.customRightColorRed), forKey: Key.customRightColorRed)
+            defaults.set(Double(newValue.customRightColorGreen), forKey: Key.customRightColorGreen)
+            defaults.set(Double(newValue.customRightColorBlue), forKey: Key.customRightColorBlue)
+            defaults.set(Double(newValue.customDragColorRed), forKey: Key.customDragColorRed)
+            defaults.set(Double(newValue.customDragColorGreen), forKey: Key.customDragColorGreen)
+            defaults.set(Double(newValue.customDragColorBlue), forKey: Key.customDragColorBlue)
             NotificationCenter.default.post(name: Self.didChangeNotification, object: self)
         }
     }
@@ -182,9 +279,19 @@ final class SettingsStore {
             Key.intensity: Double(defaults.intensity),
             Key.duration: defaults.duration,
             Key.colorPreset: defaults.colorPreset.rawValue,
+            Key.customColorMode: defaults.customColorMode.rawValue,
             Key.customColorRed: Double(defaults.customColorRed),
             Key.customColorGreen: Double(defaults.customColorGreen),
-            Key.customColorBlue: Double(defaults.customColorBlue)
+            Key.customColorBlue: Double(defaults.customColorBlue),
+            Key.customLeftColorRed: Double(defaults.customLeftColorRed),
+            Key.customLeftColorGreen: Double(defaults.customLeftColorGreen),
+            Key.customLeftColorBlue: Double(defaults.customLeftColorBlue),
+            Key.customRightColorRed: Double(defaults.customRightColorRed),
+            Key.customRightColorGreen: Double(defaults.customRightColorGreen),
+            Key.customRightColorBlue: Double(defaults.customRightColorBlue),
+            Key.customDragColorRed: Double(defaults.customDragColorRed),
+            Key.customDragColorGreen: Double(defaults.customDragColorGreen),
+            Key.customDragColorBlue: Double(defaults.customDragColorBlue)
         ])
     }
 }

--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -23,6 +23,9 @@ struct ClickSettings: Equatable {
     var customRightColorRed: CGFloat
     var customRightColorGreen: CGFloat
     var customRightColorBlue: CGFloat
+    var customMiddleColorRed: CGFloat
+    var customMiddleColorGreen: CGFloat
+    var customMiddleColorBlue: CGFloat
     var customDragColorRed: CGFloat
     var customDragColorGreen: CGFloat
     var customDragColorBlue: CGFloat
@@ -50,6 +53,15 @@ struct ClickSettings: Equatable {
             calibratedRed: customRightColorRed.sanitizedColorComponent,
             green: customRightColorGreen.sanitizedColorComponent,
             blue: customRightColorBlue.sanitizedColorComponent,
+            alpha: 1
+        )
+    }
+
+    var customMiddleColor: NSColor {
+        NSColor(
+            calibratedRed: customMiddleColorRed.sanitizedColorComponent,
+            green: customMiddleColorGreen.sanitizedColorComponent,
+            blue: customMiddleColorBlue.sanitizedColorComponent,
             alpha: 1
         )
     }
@@ -86,6 +98,9 @@ struct ClickSettings: Equatable {
         customRightColorRed: 1.0,
         customRightColorGreen: 0.46,
         customRightColorBlue: 0.19,
+        customMiddleColorRed: 0.27,
+        customMiddleColorGreen: 0.92,
+        customMiddleColorBlue: 0.58,
         customDragColorRed: 0.92,
         customDragColorGreen: 0.84,
         customDragColorBlue: 0.22
@@ -109,6 +124,7 @@ enum CustomClickColorMode: String, CaseIterable, Equatable {
 enum CustomClickColorTarget {
     case left
     case right
+    case middle
     case drag
 }
 
@@ -197,6 +213,9 @@ final class SettingsStore {
         static let customRightColorRed = "customRightColorRed"
         static let customRightColorGreen = "customRightColorGreen"
         static let customRightColorBlue = "customRightColorBlue"
+        static let customMiddleColorRed = "customMiddleColorRed"
+        static let customMiddleColorGreen = "customMiddleColorGreen"
+        static let customMiddleColorBlue = "customMiddleColorBlue"
         static let customDragColorRed = "customDragColorRed"
         static let customDragColorGreen = "customDragColorGreen"
         static let customDragColorBlue = "customDragColorBlue"
@@ -234,6 +253,9 @@ final class SettingsStore {
                 customRightColorRed: CGFloat(defaults.double(forKey: Key.customRightColorRed)).sanitizedColorComponent,
                 customRightColorGreen: CGFloat(defaults.double(forKey: Key.customRightColorGreen)).sanitizedColorComponent,
                 customRightColorBlue: CGFloat(defaults.double(forKey: Key.customRightColorBlue)).sanitizedColorComponent,
+                customMiddleColorRed: CGFloat(defaults.double(forKey: Key.customMiddleColorRed)).sanitizedColorComponent,
+                customMiddleColorGreen: CGFloat(defaults.double(forKey: Key.customMiddleColorGreen)).sanitizedColorComponent,
+                customMiddleColorBlue: CGFloat(defaults.double(forKey: Key.customMiddleColorBlue)).sanitizedColorComponent,
                 customDragColorRed: CGFloat(defaults.double(forKey: Key.customDragColorRed)).sanitizedColorComponent,
                 customDragColorGreen: CGFloat(defaults.double(forKey: Key.customDragColorGreen)).sanitizedColorComponent,
                 customDragColorBlue: CGFloat(defaults.double(forKey: Key.customDragColorBlue)).sanitizedColorComponent
@@ -262,6 +284,9 @@ final class SettingsStore {
             defaults.set(Double(newValue.customRightColorRed), forKey: Key.customRightColorRed)
             defaults.set(Double(newValue.customRightColorGreen), forKey: Key.customRightColorGreen)
             defaults.set(Double(newValue.customRightColorBlue), forKey: Key.customRightColorBlue)
+            defaults.set(Double(newValue.customMiddleColorRed), forKey: Key.customMiddleColorRed)
+            defaults.set(Double(newValue.customMiddleColorGreen), forKey: Key.customMiddleColorGreen)
+            defaults.set(Double(newValue.customMiddleColorBlue), forKey: Key.customMiddleColorBlue)
             defaults.set(Double(newValue.customDragColorRed), forKey: Key.customDragColorRed)
             defaults.set(Double(newValue.customDragColorGreen), forKey: Key.customDragColorGreen)
             defaults.set(Double(newValue.customDragColorBlue), forKey: Key.customDragColorBlue)
@@ -300,6 +325,9 @@ final class SettingsStore {
             Key.customRightColorRed: Double(defaults.customRightColorRed),
             Key.customRightColorGreen: Double(defaults.customRightColorGreen),
             Key.customRightColorBlue: Double(defaults.customRightColorBlue),
+            Key.customMiddleColorRed: Double(defaults.customMiddleColorRed),
+            Key.customMiddleColorGreen: Double(defaults.customMiddleColorGreen),
+            Key.customMiddleColorBlue: Double(defaults.customMiddleColorBlue),
             Key.customDragColorRed: Double(defaults.customDragColorRed),
             Key.customDragColorGreen: Double(defaults.customDragColorGreen),
             Key.customDragColorBlue: Double(defaults.customDragColorBlue)

--- a/Sources/ClickLight/SettingsWindowController.swift
+++ b/Sources/ClickLight/SettingsWindowController.swift
@@ -106,6 +106,7 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
     }
 
     func refreshSystemState() {
+        launchAtLogin.refresh()
         launchAtLoginEnabled = launchAtLogin.isEnabled
         accessibilityTrusted = permissions.isAccessibilityTrusted
     }

--- a/Sources/ClickLight/SettingsWindowController.swift
+++ b/Sources/ClickLight/SettingsWindowController.swift
@@ -101,7 +101,6 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
     }
 
     func refreshSystemState() {
-        launchAtLogin.refresh()
         launchAtLoginEnabled = launchAtLogin.isEnabled
         accessibilityTrusted = permissions.isAccessibilityTrusted
     }

--- a/Sources/ClickLight/SettingsWindowController.swift
+++ b/Sources/ClickLight/SettingsWindowController.swift
@@ -8,14 +8,12 @@ final class SettingsWindowController: NSWindowController {
     init(
         settingsStore: SettingsStore,
         launchAtLogin: LaunchAtLoginManaging,
-        permissions: PermissionController,
-        onTestPulse: @escaping () -> Void
+        permissions: PermissionController
     ) {
         let viewModel = ClickLightSettingsViewModel(
             settingsStore: settingsStore,
             launchAtLogin: launchAtLogin,
-            permissions: permissions,
-            onTestPulse: onTestPulse
+            permissions: permissions
         )
         self.viewModel = viewModel
 
@@ -55,7 +53,6 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
     private let settingsStore: SettingsStore
     private let launchAtLogin: LaunchAtLoginManaging
     private let permissions: PermissionController
-    private let onTestPulse: () -> Void
 
     @Published private(set) var settings: ClickSettings
     @Published private(set) var launchAtLoginEnabled: Bool = false
@@ -65,13 +62,11 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
     init(
         settingsStore: SettingsStore,
         launchAtLogin: LaunchAtLoginManaging,
-        permissions: PermissionController,
-        onTestPulse: @escaping () -> Void
+        permissions: PermissionController
     ) {
         self.settingsStore = settingsStore
         self.launchAtLogin = launchAtLogin
         self.permissions = permissions
-        self.onTestPulse = onTestPulse
         self.settings = settingsStore.settings
         super.init()
         self.launchAtLoginEnabled = launchAtLogin.isEnabled
@@ -203,10 +198,6 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
             $0.colorPreset = .custom
             $0.customColorMode = .byClick
         }
-    }
-
-    func previewPulse() {
-        onTestPulse()
     }
 
     func resetToDefaults() {

--- a/Sources/ClickLight/SettingsWindowController.swift
+++ b/Sources/ClickLight/SettingsWindowController.swift
@@ -190,6 +190,10 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
                 $0.customRightColorRed = rgb.redComponent
                 $0.customRightColorGreen = rgb.greenComponent
                 $0.customRightColorBlue = rgb.blueComponent
+            case .middle:
+                $0.customMiddleColorRed = rgb.redComponent
+                $0.customMiddleColorGreen = rgb.greenComponent
+                $0.customMiddleColorBlue = rgb.blueComponent
             case .drag:
                 $0.customDragColorRed = rgb.redComponent
                 $0.customDragColorGreen = rgb.greenComponent

--- a/Sources/ClickLight/SettingsWindowController.swift
+++ b/Sources/ClickLight/SettingsWindowController.swift
@@ -174,6 +174,29 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
             $0.customColorGreen = rgb.greenComponent
             $0.customColorBlue = rgb.blueComponent
             $0.colorPreset = .custom
+            $0.customColorMode = .all
+        }
+    }
+
+    func applyCustomColor(_ color: NSColor, to target: CustomClickColorTarget) {
+        guard let rgb = color.usingColorSpace(.deviceRGB) else { return }
+        update {
+            switch target {
+            case .left:
+                $0.customLeftColorRed = rgb.redComponent
+                $0.customLeftColorGreen = rgb.greenComponent
+                $0.customLeftColorBlue = rgb.blueComponent
+            case .right:
+                $0.customRightColorRed = rgb.redComponent
+                $0.customRightColorGreen = rgb.greenComponent
+                $0.customRightColorBlue = rgb.blueComponent
+            case .drag:
+                $0.customDragColorRed = rgb.redComponent
+                $0.customDragColorGreen = rgb.greenComponent
+                $0.customDragColorBlue = rgb.blueComponent
+            }
+            $0.colorPreset = .custom
+            $0.customColorMode = .byClick
         }
     }
 

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -50,6 +50,10 @@ final class StatusController {
         )
     }
 
+    func refresh() {
+        rebuildMenu()
+    }
+
     @objc private func settingsDidChange() {
         applyStatusItemAppearance(settingsStore.settings)
         pendingMenuRebuild?.cancel()

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -10,7 +10,6 @@ final class StatusController {
     private let onCheckForUpdates: () -> Void
     private let updatesAreConfigured: () -> Bool
     private let onOpenSettings: () -> Void
-    private let onTestPulse: () -> Void
     private let onQuit: () -> Void
     private var pendingMenuRebuild: DispatchWorkItem?
 
@@ -22,7 +21,6 @@ final class StatusController {
         onCheckForUpdates: @escaping () -> Void,
         updatesAreConfigured: @escaping () -> Bool,
         onOpenSettings: @escaping () -> Void,
-        onTestPulse: @escaping () -> Void,
         onQuit: @escaping () -> Void
     ) {
         self.settingsStore = settingsStore
@@ -32,7 +30,6 @@ final class StatusController {
         self.onCheckForUpdates = onCheckForUpdates
         self.updatesAreConfigured = updatesAreConfigured
         self.onOpenSettings = onOpenSettings
-        self.onTestPulse = onTestPulse
         self.onQuit = onQuit
     }
 
@@ -150,11 +147,6 @@ final class StatusController {
         let captureItem = NSMenuItem(title: "Click Capture: \(captureStatus())", action: nil, keyEquivalent: "")
         captureItem.isEnabled = false
         menu.addItem(captureItem)
-
-        let testPulseItem = NSMenuItem(title: "Test Pulse at Pointer", action: #selector(testPulse), keyEquivalent: "")
-        testPulseItem.target = self
-        testPulseItem.isEnabled = StatusMenuAvailability.isTestPulseEnabled(isClickLightEnabled: settings.isEnabled)
-        menu.addItem(testPulseItem)
         menu.addItem(NSMenuItem.separator())
 
         let permissionTitle = permissions.isAccessibilityTrusted ? "Accessibility: Granted" : "Open Accessibility Settings..."
@@ -224,13 +216,27 @@ final class StatusController {
     private func colorSubmenu(selected: ClickColorPreset) -> NSMenuItem {
         let item = NSMenuItem(title: "Colors", action: nil, keyEquivalent: "")
         let menu = NSMenu()
-        for preset in ClickColorPreset.allCases {
+        for preset in ClickColorPreset.allCases where preset != .custom {
             let child = NSMenuItem(title: preset.title, action: #selector(selectColor(_:)), keyEquivalent: "")
             child.target = self
             child.representedObject = preset.rawValue
             child.state = preset == selected ? .on : .off
             menu.addItem(child)
         }
+
+        menu.addItem(NSMenuItem.separator())
+
+        if selected == .custom {
+            let selectedCustom = NSMenuItem(title: "Custom (Configured in Settings)", action: nil, keyEquivalent: "")
+            selectedCustom.state = .on
+            selectedCustom.isEnabled = false
+            menu.addItem(selectedCustom)
+        }
+
+        let configureCustom = NSMenuItem(title: "Configure Custom Colors...", action: #selector(openSettings), keyEquivalent: "")
+        configureCustom.target = self
+        menu.addItem(configureCustom)
+
         item.submenu = menu
         return item
     }
@@ -307,10 +313,6 @@ final class StatusController {
     @objc private func openAccessibilitySettings() {
         permissions.requestAccessibilityIfNeeded()
         permissions.openPrivacySettings()
-    }
-
-    @objc private func testPulse() {
-        onTestPulse()
     }
 
     @objc private func checkForUpdates() {

--- a/Sources/ClickLight/StatusMenuAvailability.swift
+++ b/Sources/ClickLight/StatusMenuAvailability.swift
@@ -1,5 +1,0 @@
-enum StatusMenuAvailability {
-    static func isTestPulseEnabled(isClickLightEnabled: Bool) -> Bool {
-        isClickLightEnabled
-    }
-}


### PR DESCRIPTION
Introduce a custom color mode functionality that allows users to select colors for different mouse actions. Users can choose a single color for all clicks or specify different colors for left, right, and drag actions. This enhances the customization options for ClickLight settings.

Fixes #18