### PR TITLE
Protect release metadata updates with pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Tell us about something in ClickLight that is not working correctly.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to report a ClickLight issue.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe what you expected and what happened instead.
+      placeholder: I expected... but instead...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: ClickLight version
+      description: Find this in the downloaded release, Homebrew installation, or update information.
+      placeholder: v0.4.0
+    validations:
+      required: true
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version
+      placeholder: macOS 26.x
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the smallest sequence that causes the problem.
+      placeholder: |
+        1. Open ClickLight
+        2. Enable ...
+        3. Click ...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add screenshots, recordings, permission state, or anything else that may help.
+  - type: checkboxes
+    id: permissions
+    attributes:
+      label: Accessibility permission
+      options:
+        - label: I checked whether ClickLight has Accessibility permission when this issue involves global click detection.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest an improvement for ClickLight.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: need
+    attributes:
+      label: What would this help with?
+      description: Describe the demo, presentation, or workflow problem this would solve.
+    validations:
+      required: true
+  - type: textarea
+    id: idea
+    attributes:
+      label: Proposed behavior
+      description: What would you like ClickLight to do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or examples
+      description: Link examples or describe approaches you already tried, if applicable.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What changed, and why? -->
+
+## Test Plan
+
+- [ ] Built locally with `./build-app.sh`
+- [ ] Manually tested the changed behavior
+
+## Checklist
+
+- [ ] I updated documentation if user-visible behavior changed
+- [ ] I included a screenshot or recording for visible UI changes, if relevant
+- [ ] I did not include credentials, private keys, generated app bundles, or local system files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: macos-26
     environment: release
     permissions:
-      contents: write # Required to push release metadata and create the GitHub Release.
+      contents: write # Required to create the GitHub Release and push its metadata branch.
+      pull-requests: write # Required to open the release metadata pull request.
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -111,22 +112,34 @@ jobs:
           </rss>
           EOF
 
-      - name: Commit release metadata
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          AUTH_HEADER=$(printf "x-access-token:%s" "$GITHUB_TOKEN" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" fetch origin main:main
-          git checkout main
-          git add Casks/clicklight.rb appcast.xml
-          git commit -m "Update release metadata for v${VERSION}"
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" push origin main
-
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: gh release create "v${VERSION}" ClickLight.zip --generate-notes
+
+      - name: Open release metadata pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          BRANCH="release/v${VERSION}-metadata"
+          cp Casks/clicklight.rb "$RUNNER_TEMP/clicklight.rb"
+          cp appcast.xml "$RUNNER_TEMP/appcast.xml"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          AUTH_HEADER=$(printf "x-access-token:%s" "$GH_TOKEN" | base64 | tr -d '\n')
+          git restore Casks/clicklight.rb appcast.xml
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" fetch origin main
+          git switch -c "$BRANCH" origin/main
+          cp "$RUNNER_TEMP/clicklight.rb" Casks/clicklight.rb
+          cp "$RUNNER_TEMP/appcast.xml" appcast.xml
+          git add Casks/clicklight.rb appcast.xml
+          git commit -m "Update release metadata for v${VERSION}"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" push origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Update release metadata for v${VERSION}" \
+            --body "Updates the Homebrew cask and Sparkle appcast for the published v${VERSION} release. Merge this PR to make the release available through Homebrew upgrades and in-app updates."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,4 +59,4 @@ ClickEventTap (CGEventTap + NSEvent fallback)
 
 ## Releasing
 
-Tag-triggered GitHub Actions pipeline handles signing, notarization, Sparkle `appcast.xml`, and Homebrew cask update. Manual approval is required via the `release` environment. See [docs/RELEASING.md](docs/RELEASING.md).
+The tag-triggered GitHub Actions pipeline handles signing, notarization, and GitHub Release publication, then opens a pull request for Sparkle `appcast.xml` and Homebrew cask updates. See [docs/RELEASING.md](docs/RELEASING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to ClickLight
+
+Thanks for helping improve ClickLight.
+
+## Get Started
+
+1. Fork the repository and create a branch for your change.
+2. Follow [Local Development](docs/LOCAL_DEVELOPMENT.md) to build and run the app.
+3. Keep changes focused and update documentation when behavior changes.
+4. Open a pull request against `main`.
+
+## Verify Changes
+
+Build the app from the repository root:
+
+```bash
+./build-app.sh
+```
+
+Launch the built app and manually exercise the behavior you changed. Useful checks include:
+
+- the menu bar controls and Settings window
+- **Test Pulse at Pointer**
+- click indicators in another app after granting Accessibility permission
+- any new keyboard shortcut or pointer interaction
+
+There is currently no automated test suite, so include your manual test steps in the pull request.
+
+## Pull Requests
+
+- Explain what changed and why.
+- Include screenshots or a short recording for visible UI changes.
+- Do not commit signing credentials, private keys, generated app bundles, or local system files.
+- Keep release changes separate unless you are maintaining the release workflow itself.
+
+For security vulnerabilities, do not open a public issue. See [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -61,9 +61,13 @@ ClickLight is personal software: one small presentation annoyance, fixed directl
 
 Start with [Local Development](docs/LOCAL_DEVELOPMENT.md).
 
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, testing, and pull request guidance. Please report security issues privately as described in [SECURITY.md](SECURITY.md).
+
 ## Releasing
 
-Releases are signed, notarized, published to GitHub Releases, installable with Homebrew, and prepared for Sparkle updates.
+Releases are signed, notarized, published to GitHub Releases, and followed by a reviewed metadata pull request for Homebrew and Sparkle updates.
 
 See [Releasing](docs/RELEASING.md). What's new is tracked in [GitHub Releases](https://github.com/aurorascharff/ClickLight/releases).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Version
+
+Security fixes are applied to the latest published ClickLight release.
+
+## Reporting a Vulnerability
+
+Please do not disclose vulnerabilities in a public issue or pull request.
+
+Use GitHub's private vulnerability reporting for this repository from the **Security** tab by choosing **Report a vulnerability**. Include the affected version, steps to reproduce, impact, and any suggested fix.
+
+If **Report a vulnerability** is not visible, private vulnerability reporting has not been enabled yet. Open a public issue asking for a private contact channel without including vulnerability details.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -50,7 +50,9 @@ Create a GitHub Environment named:
 release
 ```
 
-Add yourself as a required reviewer. This means a pushed tag cannot publish a signed release until you approve it.
+To add a release approval gate, add yourself as a required reviewer. Verify that the next tagged workflow run pauses for review before relying on this protection.
+
+In **Settings -> Actions -> General**, enable **Allow GitHub Actions to create and approve pull requests**. The release workflow needs permission to open its metadata pull request.
 
 ## Release Flow
 
@@ -59,7 +61,7 @@ git tag -a v0.1.0 -m "Release v0.1.0"
 git push origin v0.1.0
 ```
 
-Then approve the `release` environment in GitHub Actions.
+If the `release` environment requires approval, approve the waiting workflow run in GitHub Actions.
 
 The workflow will:
 
@@ -67,9 +69,10 @@ The workflow will:
 2. sign and notarize it
 3. zip `ClickLight.app`
 4. sign the zip for Sparkle
-5. update `appcast.xml`
-6. update `Casks/clicklight.rb`
-7. create a GitHub Release
+5. create a GitHub Release
+6. open a pull request updating `appcast.xml` and `Casks/clicklight.rb`
+
+Review and merge the generated metadata pull request after the release succeeds. That merge makes the new version available through Homebrew upgrades and Sparkle in-app updates without allowing the workflow to push directly to protected `main`.
 
 ## Release Notes
 


### PR DESCRIPTION
## Summary

- change the tagged release workflow to publish the GitHub Release, then open a PR for the Homebrew cask and Sparkle appcast updates instead of pushing directly to protected `main`
- add concise contribution, pull request, bug report, feature request, and security-reporting guidance
- update README, release docs, and agent guidance to match the protected-main release flow

## Why

`main` now requires pull requests. The existing release workflow committed `Casks/clicklight.rb` and `appcast.xml` directly to `main`, which would conflict with that rule on the next release. Keeping release metadata in a generated PR preserves the protection while leaving the signed and notarized GitHub Release automated.

## Validation

- `zizmor .` reports no findings
- validated workflow and issue-form YAML parsing
- `git diff --check` reports no whitespace errors

## Repository setup after merge

- enable **Settings -> Actions -> General -> Allow GitHub Actions to create and approve pull requests** so a release run can open its metadata PR
- enable GitHub private vulnerability reporting so the `SECURITY.md` private reporting path is available
- turn on **Require conversation resolution before merging** in the active `Protect main` ruleset
