### PR TITLE
Harden CI workflows by pinning checkout action

### DIFF
--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -1,0 +1,31 @@
+name: PR Smoke Test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build app smoke test
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          persist-credentials: false
+
+      - name: Show toolchain
+        run: swift --version
+
+      - name: Swift package build (debug)
+        run: swift build
+
+      - name: Build app bundle
+        run: ./build-app.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write # Required to push release metadata and create the GitHub Release.
 
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write # Required to push release metadata and create the GitHub Release.
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
     name: Audit GitHub Actions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
     name: Audit GitHub Actions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

This pull request updates the GitHub Actions workflows to improve CI reliability and maintainability. The main changes include adding a new smoke test workflow and updating the `actions/checkout` action version in existing workflows for better consistency and security.

**CI/CD Workflow Improvements:**

* Added a new `.github/workflows/pr-smoke.yml` workflow to run smoke tests on pull requests and manual triggers, including steps to build the app and display the Swift toolchain version.

**Dependency Updates:**

* Updated the `actions/checkout` action to a newer, specific commit (`v4`) in both `.github/workflows/release.yml` and `.github/workflows/security.yml` for improved security and reliability. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L24-R24) [[2]](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL21-R21)

## Test Plan

- [x] Built locally with `./build-app.sh`
- [x] Manually tested the changed behavior

## Checklist

- [x] I updated documentation if user-visible behavior changed
- [x] I included a screenshot or recording for visible UI changes, if relevant
- [x] I did not include credentials, private keys, generated app bundles, or local system files
