### PR TITLE
Run checks on generated release metadata pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: macos-26
     environment: release
     permissions:
+      actions: write # Required to dispatch checks for the generated metadata pull request.
       contents: write # Required to create the GitHub Release and push its metadata branch.
       pull-requests: write # Required to open the release metadata pull request.
 
@@ -143,3 +144,5 @@ jobs:
             --head "$BRANCH" \
             --title "Update release metadata for v${VERSION}" \
             --body "Updates the Homebrew cask and Sparkle appcast for the published v${VERSION} release. Merge this PR to make the release available through Homebrew upgrades and in-app updates."
+          gh workflow run security.yml --ref "$BRANCH"
+          gh workflow run pr-smoke.yml --ref "$BRANCH"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,6 +2,7 @@ name: Security
 
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

- Make the Security workflow manually dispatchable.
- After a release opens its Homebrew/Sparkle metadata PR, dispatch both the security audit and app smoke build on that metadata branch.
- Grant the release job only the `actions: write` permission required to start those checks.

## Why

Release metadata pull requests are created with `GITHUB_TOKEN`, so GitHub intentionally does not trigger `pull_request` workflows for them. Once `Audit GitHub Actions` became a required status check, generated release metadata PRs stayed blocked with no check run attached.

This keeps the required check in place while making future generated release PRs validate automatically.

## Validation

- `zizmor .`