### PR TITLE
Add live keyboard shortcut display

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Prefer not to use Homebrew? Download `ClickLight.zip` from [GitHub Releases](htt
 - Click highlights across macOS apps
 - Separate visuals for press, release, right-click, and drag
 - Optional laser pointer mode with fading freehand strokes while dragging
+- Optional live keyboard shortcut display beside the pointer
 - Dedicated settings window with sliders + presets for size, duration, intensity, and color
 - Custom color picker in Settings
 - Menu-bar quick presets for size, duration, intensity, and color
@@ -67,6 +68,8 @@ All shortcuts can be changed or disabled in Settings.
 ClickLight requires Accessibility permission to detect clicks outside its own menu-bar app. You will be prompted on first launch, or grant it manually in:
 
 **System Settings -> Privacy & Security -> Accessibility**
+
+The optional Live Keyboard Shortcuts display additionally requires **Input Monitoring**, because macOS protects keyboard input separately from mouse clicks.
 
 After enabling permission, quit ClickLight from the menu bar and reopen it.
 

--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -30,6 +30,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let launchAtLogin = LaunchAtLoginController()
     private var captureEnabledState: Bool?
     private var laserPointerEnabledState: Bool?
+    private var liveKeyboardShortcutsEnabledState: Bool?
     private var hotKeyBindingsState: [ClickShortcutAction: HotKeyBinding] = [:]
     private var hotKeyRegistrationIssuesState: [ClickShortcutAction: String] = [:]
     private var activeShortcutRecorders = 0
@@ -40,6 +41,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         permissions.requestAccessibilityIfNeeded()
         captureEnabledState = settingsStore.settings.isEnabled
         laserPointerEnabledState = settingsStore.settings.showLaserPointer
+        liveKeyboardShortcutsEnabledState = settingsStore.settings.showLiveKeyboardShortcuts
         captureController.startIfEnabled()
         statusController.start()
         configureHotKeysIfNeeded(with: settingsStore.settings, force: true)
@@ -54,6 +56,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self,
             selector: #selector(clickEventDidArrive(_:)),
             name: ClickEventTap.didReceiveClickEvent,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardShortcutEventDidArrive(_:)),
+            name: ClickEventTap.didReceiveKeyboardShortcutEvent,
             object: nil
         )
         NotificationCenter.default.addObserver(
@@ -98,13 +106,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func settingsDidChange() {
         let settings = settingsStore.settings
+        if settings.showLiveKeyboardShortcuts && liveKeyboardShortcutsEnabledState != true {
+            permissions.requestInputMonitoringIfNeeded()
+        }
         overlayCoordinator.refreshSettings()
         configureHotKeysIfNeeded(with: settings)
         let isEnabled = settings.isEnabled
         let laserPointerEnabled = settings.showLaserPointer
-        guard captureEnabledState != isEnabled || laserPointerEnabledState != laserPointerEnabled else { return }
+        let liveKeyboardShortcutsEnabled = settings.showLiveKeyboardShortcuts
+        guard captureEnabledState != isEnabled ||
+            laserPointerEnabledState != laserPointerEnabled ||
+            liveKeyboardShortcutsEnabledState != liveKeyboardShortcutsEnabled else { return }
         captureEnabledState = isEnabled
         laserPointerEnabledState = laserPointerEnabled
+        liveKeyboardShortcutsEnabledState = liveKeyboardShortcutsEnabled
         captureController.refreshEnabledState()
     }
 
@@ -158,6 +173,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func clickEventDidArrive(_ notification: Notification) {
         guard let box = notification.object as? ClickEventBox else { return }
         guard settingsWindowController?.contains(box.event.location) != true else { return }
+        overlayCoordinator.show(box.event)
+    }
+
+    @objc private func keyboardShortcutEventDidArrive(_ notification: Notification) {
+        guard let box = notification.object as? KeyboardShortcutEventBox else { return }
         overlayCoordinator.show(box.event)
     }
 

--- a/Sources/ClickLight/ClickCaptureController.swift
+++ b/Sources/ClickLight/ClickCaptureController.swift
@@ -3,7 +3,7 @@ import Foundation
 protocol ClickEventCapturing: AnyObject {
     var statusLabel: String { get }
 
-    func start(laserPointerEnabled: Bool)
+    func start(laserPointerEnabled: Bool, liveKeyboardShortcutsEnabled: Bool)
     func stop()
 }
 
@@ -23,12 +23,18 @@ final class ClickCaptureController {
 
     func startIfEnabled() {
         guard settingsStore.settings.isEnabled else { return }
-        eventTap.start(laserPointerEnabled: settingsStore.settings.showLaserPointer)
+        eventTap.start(
+            laserPointerEnabled: settingsStore.settings.showLaserPointer,
+            liveKeyboardShortcutsEnabled: settingsStore.settings.showLiveKeyboardShortcuts
+        )
     }
 
     func refreshEnabledState() {
         if settingsStore.settings.isEnabled {
-            eventTap.start(laserPointerEnabled: settingsStore.settings.showLaserPointer)
+            eventTap.start(
+                laserPointerEnabled: settingsStore.settings.showLaserPointer,
+                liveKeyboardShortcutsEnabled: settingsStore.settings.showLiveKeyboardShortcuts
+            )
         } else {
             eventTap.stop()
         }

--- a/Sources/ClickLight/ClickEvent.swift
+++ b/Sources/ClickLight/ClickEvent.swift
@@ -21,10 +21,24 @@ struct ClickEvent: Sendable {
     let timestamp: TimeInterval
 }
 
+struct KeyboardShortcutEvent: Sendable {
+    let displayString: String
+    let location: CGPoint
+    let timestamp: TimeInterval
+}
+
 final class ClickEventBox: @unchecked Sendable {
     let event: ClickEvent
 
     init(_ event: ClickEvent) {
+        self.event = event
+    }
+}
+
+final class KeyboardShortcutEventBox: @unchecked Sendable {
+    let event: KeyboardShortcutEvent
+
+    init(_ event: KeyboardShortcutEvent) {
         self.event = event
     }
 }

--- a/Sources/ClickLight/ClickEventTap.swift
+++ b/Sources/ClickLight/ClickEventTap.swift
@@ -2,11 +2,13 @@ import AppKit
 
 final class ClickEventTap: ClickEventCapturing {
     static let didReceiveClickEvent = Notification.Name("ClickLightDidReceiveClickEvent")
+    static let didReceiveKeyboardShortcutEvent = Notification.Name("ClickLightDidReceiveKeyboardShortcutEvent")
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var globalMonitor: Any?
     private var laserPointerEnabled = false
+    private var liveKeyboardShortcutsEnabled = false
 
     var statusLabel: String {
         switch (eventTap != nil, globalMonitor != nil) {
@@ -21,10 +23,12 @@ final class ClickEventTap: ClickEventCapturing {
         }
     }
 
-    func start(laserPointerEnabled: Bool) {
-        if self.laserPointerEnabled != laserPointerEnabled {
+    func start(laserPointerEnabled: Bool, liveKeyboardShortcutsEnabled: Bool) {
+        if self.laserPointerEnabled != laserPointerEnabled ||
+            self.liveKeyboardShortcutsEnabled != liveKeyboardShortcutsEnabled {
             stop()
             self.laserPointerEnabled = laserPointerEnabled
+            self.liveKeyboardShortcutsEnabled = liveKeyboardShortcutsEnabled
         }
         startEventTapIfNeeded()
         startGlobalMonitorIfNeeded()
@@ -51,6 +55,9 @@ final class ClickEventTap: ClickEventCapturing {
         ]
         if laserPointerEnabled {
             types.append(.mouseMoved)
+        }
+        if liveKeyboardShortcutsEnabled {
+            types.append(.keyDown)
         }
         let mask = types.reduce(CGEventMask(0)) { partial, eventType in
             partial | (1 << CGEventMask(eventType.rawValue))
@@ -107,8 +114,15 @@ final class ClickEventTap: ClickEventCapturing {
         if laserPointerEnabled {
             eventTypes.insert(.mouseMoved)
         }
+        if liveKeyboardShortcutsEnabled {
+            eventTypes.insert(.keyDown)
+        }
 
         globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: eventTypes) { event in
+            if event.type == .keyDown, let shortcut = Self.keyboardShortcut(from: event) {
+                Self.post(shortcut: shortcut, timestamp: event.timestamp)
+                return
+            }
             guard let kind = ClickKind(event: event) else { return }
             Self.post(kind: kind, timestamp: event.timestamp)
         }
@@ -126,6 +140,11 @@ final class ClickEventTap: ClickEventCapturing {
             if let eventTap {
                 CGEvent.tapEnable(tap: eventTap, enable: true)
             }
+            return Unmanaged.passUnretained(event)
+        }
+
+        if type == .keyDown, let nsEvent = NSEvent(cgEvent: event), let shortcut = Self.keyboardShortcut(from: nsEvent) {
+            Self.post(shortcut: shortcut, timestamp: event.timestampSeconds)
             return Unmanaged.passUnretained(event)
         }
 
@@ -147,6 +166,32 @@ final class ClickEventTap: ClickEventCapturing {
             )
             NotificationCenter.default.post(name: Self.didReceiveClickEvent, object: ClickEventBox(clickEvent))
         }
+    }
+
+    private static func post(shortcut: HotKeyBinding, timestamp: TimeInterval) {
+        DispatchQueue.main.async {
+            let shortcutEvent = KeyboardShortcutEvent(
+                displayString: shortcut.displayString,
+                location: NSEvent.mouseLocation,
+                timestamp: timestamp
+            )
+            NotificationCenter.default.post(
+                name: Self.didReceiveKeyboardShortcutEvent,
+                object: KeyboardShortcutEventBox(shortcutEvent)
+            )
+        }
+    }
+
+    private static func keyboardShortcut(from event: NSEvent) -> HotKeyBinding? {
+        let modifiers = event.modifierFlags.intersection([.command, .option, .control, .shift])
+        guard !modifiers.intersection([.command, .option, .control]).isEmpty else { return nil }
+
+        let shortcut = HotKeyBinding(
+            keyCode: Int(event.keyCode),
+            carbonModifiers: HotKeyBinding.carbonModifiers(from: modifiers)
+        )
+        guard shortcut.keyString != "?" else { return nil }
+        return shortcut
     }
 }
 

--- a/Sources/ClickLight/ClickLightSettingsView.swift
+++ b/Sources/ClickLight/ClickLightSettingsView.swift
@@ -187,6 +187,40 @@ struct ClickLightSettingsView: View {
                 }
             }
 
+            if viewModel.settings.showLiveKeyboardShortcuts {
+                SettingsCard {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack(spacing: 10) {
+                            Image(systemName: viewModel.inputMonitoringTrusted ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
+                                .font(.title3)
+                                .foregroundStyle(viewModel.inputMonitoringTrusted ? .green : .orange)
+                                .accessibilityHidden(true)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(viewModel.inputMonitoringTrusted ? "Input Monitoring Granted" : "Input Monitoring Required")
+                                    .font(.callout.weight(.medium))
+                                Text(viewModel.inputMonitoringTrusted
+                                     ? "ClickLight can observe keyboard shortcuts across the system."
+                                     : "Grant Input Monitoring access so ClickLight can show keyboard shortcuts.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                        }
+                        .accessibilityElement(children: .combine)
+                        HStack {
+                            Spacer()
+                            Button {
+                                viewModel.openInputMonitoringSettings()
+                            } label: {
+                                Label(viewModel.inputMonitoringTrusted ? "Open Input Monitoring Settings" : "Grant Access...",
+                                      systemImage: "arrow.up.right.square")
+                            }
+                            .controlSize(.regular)
+                        }
+                    }
+                }
+            }
+
             SettingsCard {
                 ModernRow(title: "Reset to Defaults",
                           subtitle: "Restore size, intensity, duration, color, and toggles.") {
@@ -398,21 +432,6 @@ struct ClickLightSettingsView: View {
                         .toggleStyle(.switch)
                         .labelsHidden()
                         .accessibilityLabel("Show Live Keyboard Shortcuts")
-                }
-                if viewModel.settings.showLiveKeyboardShortcuts {
-                    Divider().padding(.vertical, 6)
-                    ModernRow(title: viewModel.inputMonitoringTrusted ? "Input Monitoring Granted" : "Input Monitoring Required",
-                              subtitle: viewModel.inputMonitoringTrusted
-                                  ? "ClickLight can observe keyboard shortcuts across apps."
-                                  : "Allow Input Monitoring to display shortcuts outside ClickLight.") {
-                        Button {
-                            viewModel.openInputMonitoringSettings()
-                        } label: {
-                            Label(viewModel.inputMonitoringTrusted ? "Open Settings" : "Grant Access...",
-                                  systemImage: "arrow.up.right.square")
-                        }
-                        .controlSize(.regular)
-                    }
                 }
                 Divider().padding(.vertical, 6)
                 ModernRow(title: "Show Press",

--- a/Sources/ClickLight/ClickLightSettingsView.swift
+++ b/Sources/ClickLight/ClickLightSettingsView.swift
@@ -392,6 +392,29 @@ struct ClickLightSettingsView: View {
                         .accessibilityLabel("Laser Pointer Mode")
                 }
                 Divider().padding(.vertical, 6)
+                ModernRow(title: "Show Live Keyboard Shortcuts",
+                          subtitle: "Display shortcut combinations beside the pointer while you use them.") {
+                    Toggle("", isOn: binding(\.showLiveKeyboardShortcuts))
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .accessibilityLabel("Show Live Keyboard Shortcuts")
+                }
+                if viewModel.settings.showLiveKeyboardShortcuts {
+                    Divider().padding(.vertical, 6)
+                    ModernRow(title: viewModel.inputMonitoringTrusted ? "Input Monitoring Granted" : "Input Monitoring Required",
+                              subtitle: viewModel.inputMonitoringTrusted
+                                  ? "ClickLight can observe keyboard shortcuts across apps."
+                                  : "Allow Input Monitoring to display shortcuts outside ClickLight.") {
+                        Button {
+                            viewModel.openInputMonitoringSettings()
+                        } label: {
+                            Label(viewModel.inputMonitoringTrusted ? "Open Settings" : "Grant Access...",
+                                  systemImage: "arrow.up.right.square")
+                        }
+                        .controlSize(.regular)
+                    }
+                }
+                Divider().padding(.vertical, 6)
                 ModernRow(title: "Show Press",
                           subtitle: "Highlight when the mouse button goes down.") {
                     Toggle("", isOn: binding(\.showPress))

--- a/Sources/ClickLight/ClickOverlayView.swift
+++ b/Sources/ClickLight/ClickOverlayView.swift
@@ -7,6 +7,7 @@ final class ClickOverlayView: NSView {
     private var laserCursor: LaserCursor?
     private var activeLaserStroke: LaserStroke?
     private var completedLaserStrokes: [LaserStroke] = []
+    private var liveShortcutLabel: LiveShortcutLabel?
     private var displayLink: Timer?
 
     init(screenFrame: CGRect, settings: ClickSettings) {
@@ -27,6 +28,10 @@ final class ClickOverlayView: NSView {
             laserCursor = nil
             activeLaserStroke = nil
             completedLaserStrokes = []
+            needsDisplay = true
+        }
+        if !settings.showLiveKeyboardShortcuts {
+            liveShortcutLabel = nil
             needsDisplay = true
         }
     }
@@ -70,6 +75,20 @@ final class ClickOverlayView: NSView {
         needsDisplay = true
     }
 
+    func show(shortcut: KeyboardShortcutEvent, settings: ClickSettings) {
+        self.settings = settings
+        liveShortcutLabel = LiveShortcutLabel(
+            text: shortcut.displayString,
+            point: CGPoint(
+                x: shortcut.location.x - screenFrame.minX,
+                y: shortcut.location.y - screenFrame.minY
+            ),
+            startTime: CACurrentMediaTime()
+        )
+        startDisplayLink()
+        needsDisplay = true
+    }
+
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
         guard let context = NSGraphicsContext.current?.cgContext else { return }
@@ -77,13 +96,21 @@ final class ClickOverlayView: NSView {
         let now = CACurrentMediaTime()
         pulses = pulses.filter { !$0.isExpired(at: now) }
         completedLaserStrokes = completedLaserStrokes.filter { !$0.isExpired(at: now) }
+        if liveShortcutLabel?.isExpired(at: now) == true {
+            liveShortcutLabel = nil
+        }
 
         drawLaser(at: now, in: context)
         for pulse in pulses {
             draw(pulse: pulse, at: now, in: context)
         }
+        drawLiveShortcutLabel(at: now, in: context)
 
-        if pulses.isEmpty && laserCursor?.isExpired(at: now) != false && activeLaserStroke == nil && completedLaserStrokes.isEmpty {
+        if pulses.isEmpty &&
+            laserCursor?.isExpired(at: now) != false &&
+            activeLaserStroke == nil &&
+            completedLaserStrokes.isEmpty &&
+            liveShortcutLabel == nil {
             stopDisplayLink()
         }
     }
@@ -167,6 +194,37 @@ final class ClickOverlayView: NSView {
         context.setLineWidth(5)
         context.strokePath()
         context.restoreGState()
+    }
+
+    private func drawLiveShortcutLabel(at now: CFTimeInterval, in context: CGContext) {
+        guard settings.showLiveKeyboardShortcuts, let label = liveShortcutLabel else { return }
+
+        let alpha = label.alpha(at: now)
+        let font = NSFont.monospacedSystemFont(ofSize: 18, weight: .semibold)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white.withAlphaComponent(alpha)
+        ]
+        let textSize = (label.text as NSString).size(withAttributes: attributes)
+        let padding = CGSize(width: 13, height: 8)
+        let size = CGSize(width: textSize.width + padding.width * 2, height: textSize.height + padding.height * 2)
+        let proposedOrigin = CGPoint(x: label.point.x + 18, y: label.point.y + 18)
+        let origin = CGPoint(
+            x: min(max(10, proposedOrigin.x), bounds.width - size.width - 10),
+            y: min(max(10, proposedOrigin.y), bounds.height - size.height - 10)
+        )
+        let rect = CGRect(origin: origin, size: size)
+
+        context.saveGState()
+        context.setFillColor(NSColor(calibratedWhite: 0.06, alpha: 0.88 * alpha).cgColor)
+        context.addPath(CGPath(roundedRect: rect, cornerWidth: 9, cornerHeight: 9, transform: nil))
+        context.fillPath()
+        context.restoreGState()
+
+        (label.text as NSString).draw(
+            at: CGPoint(x: rect.minX + padding.width, y: rect.minY + padding.height),
+            withAttributes: attributes
+        )
     }
 
     private func draw(pulse: ClickPulse, at now: CFTimeInterval, in context: CGContext) {
@@ -502,6 +560,26 @@ private struct LaserCursor {
 
     func isExpired(at time: CFTimeInterval) -> Bool {
         time - updatedAt >= Self.fadeDuration
+    }
+}
+
+private struct LiveShortcutLabel {
+    static let visibleDuration: TimeInterval = 0.72
+    static let fadeDuration: TimeInterval = 0.28
+
+    let text: String
+    let point: CGPoint
+    let startTime: CFTimeInterval
+
+    func alpha(at time: CFTimeInterval) -> CGFloat {
+        let elapsed = time - startTime
+        guard elapsed > Self.visibleDuration else { return 1 }
+        let fadeProgress = CGFloat((elapsed - Self.visibleDuration) / Self.fadeDuration)
+        return max(0, min(1, 1 - fadeProgress))
+    }
+
+    func isExpired(at time: CFTimeInterval) -> Bool {
+        time - startTime >= Self.visibleDuration + Self.fadeDuration
     }
 }
 

--- a/Sources/ClickLight/ClickOverlayWindow.swift
+++ b/Sources/ClickLight/ClickOverlayWindow.swift
@@ -36,4 +36,9 @@ final class ClickOverlayWindow: NSWindow {
         orderFrontRegardless()
         overlayView.show(event: event, settings: settings)
     }
+
+    func show(shortcut: KeyboardShortcutEvent, settings: ClickSettings) {
+        orderFrontRegardless()
+        overlayView.show(shortcut: shortcut, settings: settings)
+    }
 }

--- a/Sources/ClickLight/HotKeyBinding.swift
+++ b/Sources/ClickLight/HotKeyBinding.swift
@@ -69,18 +69,22 @@ struct HotKeyBinding: Equatable, Hashable, Sendable {
     }
 
     static func keyCodeToDisplayString(_ code: Int) -> String? {
+        if let specialKey = fallbackKeyCodeString(code) {
+            return specialKey
+        }
+
         guard let rawSource = TISCopyCurrentKeyboardLayoutInputSource() else {
-            return fallbackKeyCodeString(code)
+            return nil
         }
 
         let source = rawSource.takeRetainedValue()
         guard let dataPtr = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
-            return fallbackKeyCodeString(code)
+            return nil
         }
 
         let layoutData = Unmanaged<CFData>.fromOpaque(dataPtr).takeUnretainedValue()
         guard let bytePtr = CFDataGetBytePtr(layoutData) else {
-            return fallbackKeyCodeString(code)
+            return nil
         }
 
         return bytePtr.withMemoryRebound(to: UCKeyboardLayout.self, capacity: 1) { layout in
@@ -102,7 +106,7 @@ struct HotKeyBinding: Equatable, Hashable, Sendable {
             )
 
             guard result == noErr, length > 0 else {
-                return fallbackKeyCodeString(code)
+                return nil
             }
 
             return String(utf16CodeUnits: Array(chars.prefix(length)), count: length).uppercased()

--- a/Sources/ClickLight/OverlayCoordinator.swift
+++ b/Sources/ClickLight/OverlayCoordinator.swift
@@ -6,6 +6,7 @@ final class OverlayCoordinator {
     private var settings: ClickSettings
     private var overlaysByScreenID: [NSNumber: ClickOverlayWindow] = [:]
     private var recentEvents: [ClickEvent] = []
+    private var recentShortcutEvents: [KeyboardShortcutEvent] = []
 
     init(settingsStore: SettingsStore) {
         self.settingsStore = settingsStore
@@ -39,6 +40,19 @@ final class OverlayCoordinator {
         }
 
         overlaysByScreenID[screenID]?.show(event: event, settings: settings)
+    }
+
+    func show(_ event: KeyboardShortcutEvent) {
+        guard settings.isEnabled, settings.showLiveKeyboardShortcuts else { return }
+        guard shouldAccept(event) else { return }
+        guard let screen = screen(containing: event.location) else { return }
+
+        let screenID = screen.identifier
+        if overlaysByScreenID[screenID] == nil {
+            rebuildOverlays()
+        }
+
+        overlaysByScreenID[screenID]?.show(shortcut: event, settings: settings)
     }
 
     @objc private func screenParametersDidChange() {
@@ -83,6 +97,18 @@ final class OverlayCoordinator {
         }
         if !duplicate {
             recentEvents.append(event)
+        }
+        return !duplicate
+    }
+
+    private func shouldAccept(_ event: KeyboardShortcutEvent) -> Bool {
+        let now = CACurrentMediaTime()
+        recentShortcutEvents = recentShortcutEvents.filter { now - $0.timestamp < 0.1 }
+        let duplicate = recentShortcutEvents.contains { existing in
+            existing.displayString == event.displayString
+        }
+        if !duplicate {
+            recentShortcutEvents.append(event)
         }
         return !duplicate
     }

--- a/Sources/ClickLight/PermissionController.swift
+++ b/Sources/ClickLight/PermissionController.swift
@@ -7,14 +7,30 @@ final class PermissionController {
         AXIsProcessTrusted()
     }
 
+    var isInputMonitoringTrusted: Bool {
+        CGPreflightListenEventAccess()
+    }
+
     func requestAccessibilityIfNeeded() {
         guard !AXIsProcessTrusted() else { return }
         let options = ["AXTrustedCheckOptionPrompt": true] as CFDictionary
         AXIsProcessTrustedWithOptions(options)
     }
 
+    func requestInputMonitoringIfNeeded() {
+        guard !CGPreflightListenEventAccess() else { return }
+        CGRequestListenEventAccess()
+    }
+
     func openPrivacySettings() {
         let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+        if let url {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    func openInputMonitoringSettings() {
+        let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent")
         if let url {
             NSWorkspace.shared.open(url)
         }

--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -8,6 +8,7 @@ struct ClickSettings: Equatable {
     var showMiddleClick: Bool
     var showDrag: Bool
     var showLaserPointer: Bool
+    var showLiveKeyboardShortcuts: Bool
     var showMenuBarText: Bool
     var size: CGFloat
     var intensity: CGFloat
@@ -90,6 +91,7 @@ struct ClickSettings: Equatable {
         showMiddleClick: true,
         showDrag: true,
         showLaserPointer: false,
+        showLiveKeyboardShortcuts: false,
         showMenuBarText: false,
         size: 64,
         intensity: 0.7,
@@ -274,6 +276,7 @@ final class SettingsStore {
         static let showMiddleClick = "showMiddleClick"
         static let showDrag = "showDrag"
         static let showLaserPointer = "showLaserPointer"
+        static let showLiveKeyboardShortcuts = "showLiveKeyboardShortcuts"
         static let showMenuBarText = "showMenuBarText"
         static let size = "size"
         static let intensity = "intensity"
@@ -335,6 +338,7 @@ final class SettingsStore {
                 showMiddleClick: defaults.bool(forKey: Key.showMiddleClick),
                 showDrag: defaults.bool(forKey: Key.showDrag),
                 showLaserPointer: defaults.bool(forKey: Key.showLaserPointer),
+                showLiveKeyboardShortcuts: defaults.bool(forKey: Key.showLiveKeyboardShortcuts),
                 showMenuBarText: defaults.bool(forKey: Key.showMenuBarText),
                 size: CGFloat(defaults.double(forKey: Key.size)),
                 intensity: CGFloat(defaults.double(forKey: Key.intensity)),
@@ -401,6 +405,7 @@ final class SettingsStore {
             defaults.set(newValue.showMiddleClick, forKey: Key.showMiddleClick)
             defaults.set(newValue.showDrag, forKey: Key.showDrag)
             defaults.set(newValue.showLaserPointer, forKey: Key.showLaserPointer)
+            defaults.set(newValue.showLiveKeyboardShortcuts, forKey: Key.showLiveKeyboardShortcuts)
             defaults.set(newValue.showMenuBarText, forKey: Key.showMenuBarText)
             defaults.set(Double(newValue.size), forKey: Key.size)
             defaults.set(Double(newValue.intensity), forKey: Key.intensity)
@@ -464,6 +469,7 @@ final class SettingsStore {
             Key.showMiddleClick: defaults.showMiddleClick,
             Key.showDrag: defaults.showDrag,
             Key.showLaserPointer: defaults.showLaserPointer,
+            Key.showLiveKeyboardShortcuts: defaults.showLiveKeyboardShortcuts,
             Key.showMenuBarText: defaults.showMenuBarText,
             Key.size: Double(defaults.size),
             Key.intensity: Double(defaults.intensity),

--- a/Sources/ClickLight/SettingsWindowController.swift
+++ b/Sources/ClickLight/SettingsWindowController.swift
@@ -60,6 +60,7 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
     @Published private(set) var settings: ClickSettings
     @Published private(set) var launchAtLoginEnabled: Bool = false
     @Published private(set) var accessibilityTrusted: Bool = false
+    @Published private(set) var inputMonitoringTrusted: Bool = false
     @Published var launchAtLoginErrorMessage: String?
     @Published private(set) var shortcutErrors: [ClickShortcutAction: String] = [:]
     @Published private(set) var hotKeyRegistrationIssues: [ClickShortcutAction: String] = [:]
@@ -78,6 +79,7 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
         super.init()
         self.launchAtLoginEnabled = launchAtLogin.isEnabled
         self.accessibilityTrusted = permissions.isAccessibilityTrusted
+        self.inputMonitoringTrusted = permissions.isInputMonitoringTrusted
         self.shortcutErrors = Self.findShortcutConflicts(in: settings)
         self.hotKeyRegistrationIssues = hotKeyRegistrationIssuesProvider()
         NotificationCenter.default.addObserver(
@@ -133,6 +135,7 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
     func refreshSystemState() {
         launchAtLoginEnabled = launchAtLogin.isEnabled
         accessibilityTrusted = permissions.isAccessibilityTrusted
+        inputMonitoringTrusted = permissions.isInputMonitoringTrusted
     }
 
     func setLaunchAtLogin(_ enabled: Bool) {
@@ -148,6 +151,11 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
     func openAccessibilitySettings() {
         permissions.requestAccessibilityIfNeeded()
         permissions.openPrivacySettings()
+    }
+
+    func openInputMonitoringSettings() {
+        permissions.requestInputMonitoringIfNeeded()
+        permissions.openInputMonitoringSettings()
     }
 
     var sizePresetSelection: String {

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -104,6 +104,11 @@ final class StatusController: NSObject {
             action: #selector(toggleLaserPointer(_:)),
             shortcut: settings.shortcutBindings[.toggleLaserPointer]
         ))
+        menu.addItem(toggleItem(
+            title: "Show Live Keyboard Shortcuts",
+            isOn: settings.showLiveKeyboardShortcuts,
+            action: #selector(toggleLiveKeyboardShortcuts(_:))
+        ))
         menu.addItem(NSMenuItem.separator())
 
         menu.addItem(toggleItem(
@@ -181,6 +186,13 @@ final class StatusController: NSObject {
         permissionItem.target = self
         permissionItem.isEnabled = true
         menu.addItem(permissionItem)
+        if settings.showLiveKeyboardShortcuts {
+            let inputTitle = permissions.isInputMonitoringTrusted ? "Input Monitoring: Granted" : "Open Input Monitoring Settings..."
+            let inputItem = NSMenuItem(title: inputTitle, action: #selector(openInputMonitoringSettings), keyEquivalent: "")
+            inputItem.target = self
+            inputItem.isEnabled = true
+            menu.addItem(inputItem)
+        }
 
         menu.addItem(NSMenuItem.separator())
         let updatesConfigured = updatesAreConfigured()
@@ -322,6 +334,11 @@ final class StatusController: NSObject {
         settingsStore.update { $0.showLaserPointer.toggle() }
     }
 
+    @objc private func toggleLiveKeyboardShortcuts(_ sender: NSMenuItem) {
+        dismissMenu(from: sender)
+        settingsStore.update { $0.showLiveKeyboardShortcuts.toggle() }
+    }
+
     @objc private func toggleMenuBarText() {
         settingsStore.update { $0.showMenuBarText.toggle() }
     }
@@ -362,6 +379,11 @@ final class StatusController: NSObject {
     @objc private func openAccessibilitySettings() {
         permissions.requestAccessibilityIfNeeded()
         permissions.openPrivacySettings()
+    }
+
+    @objc private func openInputMonitoringSettings() {
+        permissions.requestInputMonitoringIfNeeded()
+        permissions.openInputMonitoringSettings()
     }
 
     @objc private func checkForUpdates() {


### PR DESCRIPTION
## Summary

- add an opt-in **Show Live Keyboard Shortcuts** toggle in the menu and Event Visibility settings
- display modifier-based shortcuts such as `Command + C` beside the pointer for a moment, without exposing ordinary typing
- add Input Monitoring permission guidance and controls for the keyboard-specific permission
- document the optional feature and its permission requirement in the README

## Why

ClickLight already makes clicks visible during a live demo. This adds the same visibility for keyboard-driven actions, so an audience can follow shortcuts without the presenter having to narrate each key combination.

Keyboard events are protected separately by macOS, so this feature is off by default and requires Input Monitoring only when enabled.

## Test Plan

- [x] Built locally with `./build-app.sh`
- [x] Ran `zizmor .` with no findings
- [x] Manually tested the changed behavior in a local preview app
- [x] Enabled Input Monitoring for the preview app and verified shortcut labels appear beside the pointer

## Checklist

- [x] I updated documentation because user-visible behavior changed
- [ ] I included a screenshot or recording for the visible UI change, if relevant
- [x] I did not include credentials, private keys, generated app bundles, or local system files
