### PR TITLE
Add local daily click activity view

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Prefer not to use Homebrew? Download `ClickLight.zip` from [GitHub Releases](htt
 - Separate visuals for press, release, right-click, and drag
 - Optional laser pointer mode with fading freehand strokes while dragging
 - Optional live keyboard shortcut display beside the pointer
+- Local daily click activity chart with a resettable seven-day history
 - Dedicated settings window with sliders + presets for size, duration, intensity, and color
 - Custom color picker in Settings
 - Menu-bar quick presets for size, duration, intensity, and color

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Prefer not to use Homebrew? Download `ClickLight.zip` from [GitHub Releases](htt
 - Optional laser pointer mode with fading freehand strokes while dragging
 - Optional live keyboard shortcut display beside the pointer
 - Local daily click activity chart with a resettable seven-day history
+- Optional daily click count in the menu bar
 - Dedicated settings window with sliders + presets for size, duration, intensity, and color
 - Custom color picker in Settings
 - Menu-bar quick presets for size, duration, intensity, and color

--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -5,6 +5,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     static let hotKeyRegistrationIssuesDidChangeNotification = Notification.Name("ClickLightHotKeyRegistrationIssuesDidChange")
 
     private let settingsStore = SettingsStore()
+    private let activityStore = ClickActivityStore()
     private var settingsWindowController: SettingsWindowController?
     private let hotKeyManager = HotKeyManager()
     private lazy var overlayCoordinator = OverlayCoordinator(settingsStore: settingsStore)
@@ -173,6 +174,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func clickEventDidArrive(_ notification: Notification) {
         guard let box = notification.object as? ClickEventBox else { return }
         guard settingsWindowController?.contains(box.event.location) != true else { return }
+        activityStore.record(box.event)
         overlayCoordinator.show(box.event)
     }
 
@@ -206,6 +208,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func openSettings() {
         let controller = settingsWindowController ?? SettingsWindowController(
             settingsStore: settingsStore,
+            activityStore: activityStore,
             launchAtLogin: launchAtLogin,
             permissions: permissions,
             hotKeyRegistrationIssuesProvider: { [weak self] in

--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -12,6 +12,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private lazy var captureController = ClickCaptureController(settingsStore: settingsStore, eventTap: eventTap)
     private lazy var statusController = StatusController(
         settingsStore: settingsStore,
+        activityStore: activityStore,
         permissions: permissions,
         launchAtLogin: launchAtLogin,
         onCheckForUpdates: { UpdateChecker.shared.checkForUpdates() },

--- a/Sources/ClickLight/ClickActivityStore.swift
+++ b/Sources/ClickLight/ClickActivityStore.swift
@@ -119,7 +119,7 @@ final class ClickActivityStore: ObservableObject {
     }
 
     private func pruneAndSave() {
-        guard let cutoff = calendar.date(byAdding: .day, value: -365, to: Date()) else { return }
+        guard let cutoff = calendar.date(byAdding: .day, value: -6, to: Date()) else { return }
         let cutoffID = dayID(for: cutoff)
         days = days.filter { $0.id >= cutoffID }.sorted { $0.id < $1.id }
         guard let encoded = try? encoder.encode(days) else { return }

--- a/Sources/ClickLight/ClickActivityStore.swift
+++ b/Sources/ClickLight/ClickActivityStore.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Combine
+import QuartzCore
+
+struct ClickActivityDay: Codable, Equatable, Identifiable {
+    let id: String
+    var primaryClicks: Int
+    var secondaryClicks: Int
+    var middleClicks: Int
+    var drags: Int
+
+    var totalClicks: Int {
+        primaryClicks + secondaryClicks + middleClicks
+    }
+}
+
+@MainActor
+final class ClickActivityStore: ObservableObject {
+    private enum Key {
+        static let days = "clickActivityDays"
+    }
+
+    @Published private(set) var days: [ClickActivityDay]
+
+    private let defaults: UserDefaults
+    private let calendar: Calendar
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private var recentEvents: [ClickEvent] = []
+    private var hasRecordedCurrentDrag = false
+
+    init(defaults: UserDefaults = .standard, calendar: Calendar = .autoupdatingCurrent) {
+        self.defaults = defaults
+        self.calendar = calendar
+        self.days = Self.loadDays(from: defaults)
+        pruneAndSave()
+    }
+
+    var lastSevenDays: [ClickActivityDay] {
+        (0..<7).reversed().compactMap { offset in
+            guard let date = calendar.date(byAdding: .day, value: -offset, to: Date()) else {
+                return nil
+            }
+            let id = dayID(for: date)
+            return days.first(where: { $0.id == id }) ?? Self.emptyDay(id: id)
+        }
+    }
+
+    var today: ClickActivityDay {
+        let id = dayID(for: Date())
+        return days.first(where: { $0.id == id }) ?? Self.emptyDay(id: id)
+    }
+
+    func record(_ event: ClickEvent) {
+        guard shouldAccept(event) else { return }
+
+        switch event.kind {
+        case .leftDown:
+            hasRecordedCurrentDrag = false
+            add { $0.primaryClicks += 1 }
+        case .rightDown:
+            hasRecordedCurrentDrag = false
+            add { $0.secondaryClicks += 1 }
+        case .middleDown:
+            hasRecordedCurrentDrag = false
+            add { $0.middleClicks += 1 }
+        case .drag where !hasRecordedCurrentDrag:
+            hasRecordedCurrentDrag = true
+            add { $0.drags += 1 }
+        case .leftUp, .rightUp, .middleUp:
+            hasRecordedCurrentDrag = false
+        case .drag, .move:
+            break
+        }
+    }
+
+    func reset() {
+        days = []
+        defaults.removeObject(forKey: Key.days)
+    }
+
+    func label(for day: ClickActivityDay) -> String {
+        guard let date = date(from: day.id) else { return day.id }
+        if calendar.isDateInToday(date) {
+            return "Today"
+        }
+        return date.formatted(.dateTime.weekday(.abbreviated))
+    }
+
+    func accessibilityLabel(for day: ClickActivityDay) -> String {
+        let dateLabel = date(from: day.id)?.formatted(date: .complete, time: .omitted) ?? day.id
+        return "\(dateLabel), \(day.totalClicks) clicks"
+    }
+
+    private func add(_ update: (inout ClickActivityDay) -> Void) {
+        let id = dayID(for: Date())
+        if let index = days.firstIndex(where: { $0.id == id }) {
+            update(&days[index])
+        } else {
+            var day = Self.emptyDay(id: id)
+            update(&day)
+            days.append(day)
+        }
+        pruneAndSave()
+    }
+
+    private func shouldAccept(_ event: ClickEvent) -> Bool {
+        let now = CACurrentMediaTime()
+        recentEvents = recentEvents.filter { now - $0.timestamp < 0.1 }
+        let duplicate = recentEvents.contains {
+            $0.kind == event.kind &&
+            abs($0.location.x - event.location.x) < 3 &&
+            abs($0.location.y - event.location.y) < 3
+        }
+        if !duplicate {
+            recentEvents.append(event)
+        }
+        return !duplicate
+    }
+
+    private func pruneAndSave() {
+        guard let cutoff = calendar.date(byAdding: .day, value: -365, to: Date()) else { return }
+        let cutoffID = dayID(for: cutoff)
+        days = days.filter { $0.id >= cutoffID }.sorted { $0.id < $1.id }
+        guard let encoded = try? encoder.encode(days) else { return }
+        defaults.set(encoded, forKey: Key.days)
+    }
+
+    private func dayID(for date: Date) -> String {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(
+            format: "%04d-%02d-%02d",
+            components.year ?? 0,
+            components.month ?? 0,
+            components.day ?? 0
+        )
+    }
+
+    private func date(from id: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = calendar.timeZone
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.date(from: id)
+    }
+
+    private static func loadDays(from defaults: UserDefaults) -> [ClickActivityDay] {
+        guard let data = defaults.data(forKey: Key.days),
+              let saved = try? JSONDecoder().decode([ClickActivityDay].self, from: data) else {
+            return []
+        }
+        return saved
+    }
+
+    private static func emptyDay(id: String) -> ClickActivityDay {
+        ClickActivityDay(id: id, primaryClicks: 0, secondaryClicks: 0, middleClicks: 0, drags: 0)
+    }
+}

--- a/Sources/ClickLight/ClickLightSettingsView.swift
+++ b/Sources/ClickLight/ClickLightSettingsView.swift
@@ -150,12 +150,22 @@ struct ClickLightSettingsView: View {
             }
 
             SettingsCard {
-                ModernRow(title: "Show Menu Bar Text",
-                          subtitle: "Display the ClickLight name next to the menu bar icon.") {
-                    Toggle("", isOn: binding(\.showMenuBarText))
-                        .toggleStyle(.switch)
-                        .labelsHidden()
-                        .accessibilityLabel("Show Menu Bar Text")
+                VStack(spacing: 0) {
+                    ModernRow(title: "Show Menu Bar Text",
+                              subtitle: "Display the ClickLight name next to the menu bar icon.") {
+                        Toggle("", isOn: binding(\.showMenuBarText))
+                            .toggleStyle(.switch)
+                            .labelsHidden()
+                            .accessibilityLabel("Show Menu Bar Text")
+                    }
+                    Divider().padding(.vertical, 6)
+                    ModernRow(title: "Show Click Count in Menu Bar",
+                              subtitle: "Display today's click total beside the menu bar icon.") {
+                        Toggle("", isOn: binding(\.showMenuBarClickCount))
+                            .toggleStyle(.switch)
+                            .labelsHidden()
+                            .accessibilityLabel("Show Click Count in Menu Bar")
+                    }
                 }
             }
 

--- a/Sources/ClickLight/ClickLightSettingsView.swift
+++ b/Sources/ClickLight/ClickLightSettingsView.swift
@@ -3,9 +3,11 @@ import SwiftUI
 
 struct ClickLightSettingsView: View {
     @ObservedObject var viewModel: ClickLightSettingsViewModel
+    @ObservedObject var activityStore: ClickActivityStore
     @State private var selectedPane: SettingsPane = .general
     @State private var showResetConfirmation = false
     @State private var showShortcutResetConfirmation = false
+    @State private var showActivityResetConfirmation = false
 
     var body: some View {
         NavigationSplitView {
@@ -53,6 +55,8 @@ struct ClickLightSettingsView: View {
                             shortcutsPane
                         case .events:
                             eventsPane
+                        case .activity:
+                            activityPane
                         }
                     }
                 }
@@ -553,6 +557,68 @@ struct ClickLightSettingsView: View {
         }
     }
 
+    private var activityPane: some View {
+        VStack(spacing: 16) {
+            SettingsCard(
+                title: "Daily Clicks",
+                subtitle: "Your last seven days. Stored locally on this Mac."
+            ) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(activityStore.today.totalClicks.formatted())
+                        .font(.system(size: 32, weight: .semibold, design: .rounded))
+                        .monospacedDigit()
+                    Text("clicks today")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.top, 4)
+
+                ClickActivityChart(days: activityStore.lastSevenDays, store: activityStore)
+                    .frame(height: 190)
+                    .padding(.top, 8)
+            }
+
+            SettingsCard(title: "Today") {
+                HStack(spacing: 0) {
+                    ActivityMetric(title: "Primary", value: activityStore.today.primaryClicks)
+                    Divider().frame(height: 44)
+                    ActivityMetric(title: "Right", value: activityStore.today.secondaryClicks)
+                    Divider().frame(height: 44)
+                    ActivityMetric(title: "Middle", value: activityStore.today.middleClicks)
+                    Divider().frame(height: 44)
+                    ActivityMetric(title: "Drags", value: activityStore.today.drags)
+                }
+                .padding(.vertical, 6)
+            }
+
+            SettingsCard {
+                ModernRow(
+                    title: "Reset Activity History",
+                    subtitle: "Remove all click counts stored by ClickLight."
+                ) {
+                    Button(role: .destructive) {
+                        showActivityResetConfirmation = true
+                    } label: {
+                        Label("Reset", systemImage: "arrow.counterclockwise")
+                    }
+                    .controlSize(.regular)
+                }
+            }
+        }
+        .confirmationDialog(
+            "Reset click activity history?",
+            isPresented: $showActivityResetConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Reset", role: .destructive) {
+                activityStore.reset()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the daily click totals saved on this Mac.")
+        }
+    }
+
     // MARK: - Helpers
 
     private var resolvedColor: Color {
@@ -714,6 +780,64 @@ private struct ColorSwatch: View {
     }
 }
 
+private struct ClickActivityChart: View {
+    let days: [ClickActivityDay]
+    @ObservedObject var store: ClickActivityStore
+
+    private var maximum: Int {
+        max(1, days.map(\.totalClicks).max() ?? 1)
+    }
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 12) {
+            ForEach(days) { day in
+                VStack(spacing: 6) {
+                    Text(day.totalClicks.formatted())
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+
+                    GeometryReader { geometry in
+                        VStack {
+                            Spacer(minLength: 0)
+                            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                .fill(Color.accentColor)
+                                .frame(
+                                    height: max(
+                                        day.totalClicks == 0 ? 2 : 6,
+                                        geometry.size.height * CGFloat(day.totalClicks) / CGFloat(maximum)
+                                    )
+                                )
+                        }
+                    }
+
+                    Text(store.label(for: day))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(store.accessibilityLabel(for: day))
+            }
+        }
+    }
+}
+
+private struct ActivityMetric: View {
+    let title: String
+    let value: Int
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 4) {
+            Text(value.formatted())
+                .font(.headline.monospacedDigit())
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+    }
+}
+
 private struct ClickPreviewPad: NSViewRepresentable {
     let settings: ClickSettings
 
@@ -825,6 +949,7 @@ private enum SettingsPane: String, CaseIterable, Hashable {
     case events
     case style
     case shortcuts
+    case activity
 
     var title: String {
         switch self {
@@ -836,6 +961,8 @@ private enum SettingsPane: String, CaseIterable, Hashable {
             return "Keyboard Shortcuts"
         case .events:
             return "Event Visibility"
+        case .activity:
+            return "Activity"
         }
     }
 
@@ -849,6 +976,8 @@ private enum SettingsPane: String, CaseIterable, Hashable {
             return "Set global shortcuts."
         case .events:
             return "Choose which mouse interactions trigger a pulse."
+        case .activity:
+            return "A local daily view of your clicking."
         }
     }
 
@@ -862,6 +991,8 @@ private enum SettingsPane: String, CaseIterable, Hashable {
             return "keyboard"
         case .events:
             return "cursorarrow.click.2"
+        case .activity:
+            return "chart.bar.xaxis"
         }
     }
 }

--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -10,6 +10,7 @@ struct ClickSettings: Equatable {
     var showLaserPointer: Bool
     var showLiveKeyboardShortcuts: Bool
     var showMenuBarText: Bool
+    var showMenuBarClickCount: Bool
     var size: CGFloat
     var intensity: CGFloat
     var duration: TimeInterval
@@ -93,6 +94,7 @@ struct ClickSettings: Equatable {
         showLaserPointer: false,
         showLiveKeyboardShortcuts: false,
         showMenuBarText: false,
+        showMenuBarClickCount: false,
         size: 64,
         intensity: 0.7,
         duration: 0.48,
@@ -278,6 +280,7 @@ final class SettingsStore {
         static let showLaserPointer = "showLaserPointer"
         static let showLiveKeyboardShortcuts = "showLiveKeyboardShortcuts"
         static let showMenuBarText = "showMenuBarText"
+        static let showMenuBarClickCount = "showMenuBarClickCount"
         static let size = "size"
         static let intensity = "intensity"
         static let duration = "duration"
@@ -340,6 +343,7 @@ final class SettingsStore {
                 showLaserPointer: defaults.bool(forKey: Key.showLaserPointer),
                 showLiveKeyboardShortcuts: defaults.bool(forKey: Key.showLiveKeyboardShortcuts),
                 showMenuBarText: defaults.bool(forKey: Key.showMenuBarText),
+                showMenuBarClickCount: defaults.bool(forKey: Key.showMenuBarClickCount),
                 size: CGFloat(defaults.double(forKey: Key.size)),
                 intensity: CGFloat(defaults.double(forKey: Key.intensity)),
                 duration: defaults.double(forKey: Key.duration),
@@ -407,6 +411,7 @@ final class SettingsStore {
             defaults.set(newValue.showLaserPointer, forKey: Key.showLaserPointer)
             defaults.set(newValue.showLiveKeyboardShortcuts, forKey: Key.showLiveKeyboardShortcuts)
             defaults.set(newValue.showMenuBarText, forKey: Key.showMenuBarText)
+            defaults.set(newValue.showMenuBarClickCount, forKey: Key.showMenuBarClickCount)
             defaults.set(Double(newValue.size), forKey: Key.size)
             defaults.set(Double(newValue.intensity), forKey: Key.intensity)
             defaults.set(newValue.duration, forKey: Key.duration)
@@ -471,6 +476,7 @@ final class SettingsStore {
             Key.showLaserPointer: defaults.showLaserPointer,
             Key.showLiveKeyboardShortcuts: defaults.showLiveKeyboardShortcuts,
             Key.showMenuBarText: defaults.showMenuBarText,
+            Key.showMenuBarClickCount: defaults.showMenuBarClickCount,
             Key.size: Double(defaults.size),
             Key.intensity: Double(defaults.intensity),
             Key.duration: defaults.duration,

--- a/Sources/ClickLight/SettingsWindowController.swift
+++ b/Sources/ClickLight/SettingsWindowController.swift
@@ -7,6 +7,7 @@ final class SettingsWindowController: NSWindowController {
 
     init(
         settingsStore: SettingsStore,
+        activityStore: ClickActivityStore,
         launchAtLogin: LaunchAtLoginManaging,
         permissions: PermissionController,
         hotKeyRegistrationIssuesProvider: @escaping () -> [ClickShortcutAction: String]
@@ -19,7 +20,9 @@ final class SettingsWindowController: NSWindowController {
         )
         self.viewModel = viewModel
 
-        let hosting = NSHostingController(rootView: ClickLightSettingsView(viewModel: viewModel))
+        let hosting = NSHostingController(
+            rootView: ClickLightSettingsView(viewModel: viewModel, activityStore: activityStore)
+        )
         let window = NSWindow(contentViewController: hosting)
         window.title = "ClickLight Settings"
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable]

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -1,9 +1,11 @@
 import AppKit
+import Combine
 
 @MainActor
 final class StatusController: NSObject {
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     private let settingsStore: SettingsStore
+    private let activityStore: ClickActivityStore
     private let permissions: PermissionController
     private let launchAtLogin: LaunchAtLoginManaging
     private let onCheckForUpdates: () -> Void
@@ -12,9 +14,11 @@ final class StatusController: NSObject {
     private let onQuit: () -> Void
     private let onMenuWillOpen: () -> Void
     private let onMenuDidClose: () -> Void
+    private var activityObserver: AnyCancellable?
 
     init(
         settingsStore: SettingsStore,
+        activityStore: ClickActivityStore,
         permissions: PermissionController,
         launchAtLogin: LaunchAtLoginManaging,
         onCheckForUpdates: @escaping () -> Void,
@@ -25,6 +29,7 @@ final class StatusController: NSObject {
         onMenuDidClose: @escaping () -> Void = {}
     ) {
         self.settingsStore = settingsStore
+        self.activityStore = activityStore
         self.permissions = permissions
         self.launchAtLogin = launchAtLogin
         self.onCheckForUpdates = onCheckForUpdates
@@ -48,6 +53,9 @@ final class StatusController: NSObject {
             name: SettingsStore.didChangeNotification,
             object: nil
         )
+        activityObserver = activityStore.$days.sink { [weak self] _ in
+            self?.applyStatusItemAppearance(self?.settingsStore.settings ?? .defaults)
+        }
     }
 
     func refresh() {
@@ -150,6 +158,11 @@ final class StatusController: NSObject {
             action: #selector(toggleMenuBarText)
         ))
         menu.addItem(toggleItem(
+            title: "Show Click Count in Menu Bar",
+            isOn: settings.showMenuBarClickCount,
+            action: #selector(toggleMenuBarClickCount)
+        ))
+        menu.addItem(toggleItem(
             title: "Launch at Login",
             isOn: launchAtLogin.isEnabled,
             action: #selector(toggleLaunchAtLogin)
@@ -205,6 +218,10 @@ final class StatusController: NSObject {
         updateItem.isEnabled = updatesConfigured
         menu.addItem(updateItem)
 
+        let aboutItem = NSMenuItem(title: "About ClickLight", action: #selector(showAbout), keyEquivalent: "")
+        aboutItem.target = self
+        menu.addItem(aboutItem)
+
         let quitItem = NSMenuItem(title: "Quit ClickLight", action: #selector(quit), keyEquivalent: "q")
         quitItem.target = self
         menu.addItem(quitItem)
@@ -212,8 +229,19 @@ final class StatusController: NSObject {
 
     private func applyStatusItemAppearance(_ settings: ClickSettings) {
         guard let button = statusItem.button else { return }
-        button.imagePosition = settings.showMenuBarText ? .imageLeading : .imageOnly
-        button.title = settings.showMenuBarText ? "ClickLight" : ""
+        var titleParts: [String] = []
+        if settings.showMenuBarText {
+            titleParts.append("ClickLight")
+        }
+        if settings.showMenuBarClickCount {
+            titleParts.append(compactCount(activityStore.today.totalClicks))
+        }
+        button.imagePosition = titleParts.isEmpty ? .imageOnly : .imageLeading
+        button.title = titleParts.joined(separator: " ")
+    }
+
+    private func compactCount(_ value: Int) -> String {
+        value.formatted(.number.notation(.compactName).precision(.fractionLength(0...1)))
     }
 
     private func toggleItem(
@@ -343,6 +371,10 @@ final class StatusController: NSObject {
         settingsStore.update { $0.showMenuBarText.toggle() }
     }
 
+    @objc private func toggleMenuBarClickCount() {
+        settingsStore.update { $0.showMenuBarClickCount.toggle() }
+    }
+
     @objc private func toggleLaunchAtLogin() {
         let enabled = LaunchAtLoginState.toggledValue(currentlyEnabled: launchAtLogin.isEnabled)
         do {
@@ -388,6 +420,19 @@ final class StatusController: NSObject {
 
     @objc private func checkForUpdates() {
         onCheckForUpdates()
+    }
+
+    @objc private func showAbout() {
+        let credits = NSMutableAttributedString(string: "Source on GitHub")
+        credits.addAttributes(
+            [
+                .link: URL(string: "https://github.com/aurorascharff/ClickLight")!,
+                .foregroundColor: NSColor.linkColor
+            ],
+            range: NSRange(location: 0, length: credits.length)
+        )
+        NSApp.orderFrontStandardAboutPanel(options: [.credits: credits])
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     @objc private func quit() {


### PR DESCRIPTION
## Summary

- Add an **Activity** pane in Settings with a seven-day daily click chart.
- Show today's primary, right, middle, and drag counts.
- Add an optional menu-bar display of today's compact click count.
- Add a native **About ClickLight** item with a link to the source repository.
- Store activity history locally on the Mac and provide a reset action.
- Exclude interactions inside ClickLight Settings from the recorded activity.

## Context

This is a playful local-only recap inspired by daily activity views, rather than an analytics or productivity feature. It is built on current `main`, so the existing live keyboard shortcut display remains unchanged; keyboard events are intentionally not included in this click activity chart.

## Validation

- Ran `./build-app.sh` successfully.
- Ran `zizmor .` with no findings.
- Installed and opened a separate Activity Preview app for manual testing, including the menu-bar count and About panel.
