### PR TITLE
Polish live shortcut badge display

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Prefer not to use Homebrew? Download `ClickLight.zip` from [GitHub Releases](htt
 - Click highlights across macOS apps
 - Separate visuals for press, release, right-click, and drag
 - Optional laser pointer mode with fading freehand strokes while dragging
-- Optional live keyboard shortcut display pinned to the bottom of the screen by default, with pointer-following placement and adjustable badge size available
+- Optional live keyboard shortcut display pinned to the bottom of the screen by default, with pointer-following placement and sizes through XL available
 - Local daily click activity chart with a resettable seven-day history
 - Optional daily click count in the menu bar
 - Dedicated settings window with sliders + presets for size, duration, intensity, and color

--- a/Sources/ClickLight/ClickOverlayView.swift
+++ b/Sources/ClickLight/ClickOverlayView.swift
@@ -201,7 +201,7 @@ final class ClickOverlayView: NSView {
 
         let alpha = label.alpha(at: now)
         let style = settings.liveShortcutSize
-        let font = NSFont.monospacedSystemFont(ofSize: style.fontSize, weight: .semibold)
+        let font = NSFont.systemFont(ofSize: style.fontSize, weight: .semibold)
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: NSColor.white.withAlphaComponent(alpha)

--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -223,9 +223,19 @@ enum LiveShortcutSize: String, CaseIterable, Equatable {
     case small
     case medium
     case large
+    case extraLarge
 
     var title: String {
-        rawValue.capitalized
+        switch self {
+        case .small:
+            return "Small"
+        case .medium:
+            return "Medium"
+        case .large:
+            return "Large"
+        case .extraLarge:
+            return "XL"
+        }
     }
 
     var fontSize: CGFloat {
@@ -236,6 +246,8 @@ enum LiveShortcutSize: String, CaseIterable, Equatable {
             return 18
         case .large:
             return 25
+        case .extraLarge:
+            return 34
         }
     }
 
@@ -247,6 +259,8 @@ enum LiveShortcutSize: String, CaseIterable, Equatable {
             return CGSize(width: 13, height: 8)
         case .large:
             return CGSize(width: 18, height: 11)
+        case .extraLarge:
+            return CGSize(width: 22, height: 14)
         }
     }
 
@@ -258,6 +272,8 @@ enum LiveShortcutSize: String, CaseIterable, Equatable {
             return 9
         case .large:
             return 12
+        case .extraLarge:
+            return 14
         }
     }
 }


### PR DESCRIPTION
## What Changed

- Adds an `XL` size option for the pinned live keyboard shortcut badge.
- Uses the standard macOS system font for shortcut glyphs instead of the monospaced font.
- Updates the README feature summary to mention the larger badge option.

## Why

The pinned shortcut display is meant to be readable during demos and screen sharing. `XL` makes the badge easier to see at presentation scale, and the system font gives compact strings such as `⌘U` a more native macOS look.

## Validation

- Built locally with `./build-app.sh`.
- Ran `zizmor .` with no findings.
- Installed and manually reviewed the separate preview build.
