### PR TITLE
Add randomize colors shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Prefer not to use Homebrew? Download `ClickLight.zip` from [GitHub Releases](htt
 - Custom color picker in Settings
 - Menu-bar quick presets for size, duration, intensity, and color
 - Customizable status-bar menu sections for hiding optional controls you do not use
-- Menu-bar color submenu includes one-click randomization using the same style randomizer as Settings
 - One default ClickLight toggle shortcut, with optional shortcuts for other actions
 - Optional compact menu-bar icon
 - Test pulse for verifying overlay behavior
@@ -64,7 +63,6 @@ ClickLight includes one default global shortcut for quick toggles during demos. 
 | Not set by default | Toggle Right Click |
 | Not set by default | Toggle Middle Click |
 | Not set by default | Toggle Drag |
-| Not set by default | Randomize Colors |
 | Not set by default | Toggle Live Keyboard Shortcuts |
 
 All shortcuts can be changed or disabled in Settings.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ ClickLight includes one default global shortcut for quick toggles during demos. 
 | Not set by default | Toggle Right Click |
 | Not set by default | Toggle Middle Click |
 | Not set by default | Toggle Drag |
+| Not set by default | Randomize Colors |
 | Not set by default | Toggle Live Keyboard Shortcuts |
 
 All shortcuts can be changed or disabled in Settings.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Prefer not to use Homebrew? Download `ClickLight.zip` from [GitHub Releases](htt
 - Dedicated settings window with presets, sliders, and a sidebar preview pad with Randomize
 - Custom color picker in Settings
 - Menu-bar quick presets for size, duration, intensity, and color
+- Menu-bar color submenu includes one-click randomization using the same style randomizer as Settings
 - One default ClickLight toggle shortcut, with optional shortcuts for other actions
 - Optional compact menu-bar icon
 - Test pulse for verifying overlay behavior
@@ -62,6 +63,7 @@ ClickLight includes one default global shortcut for quick toggles during demos. 
 | Not set by default | Toggle Right Click |
 | Not set by default | Toggle Middle Click |
 | Not set by default | Toggle Drag |
+| Not set by default | Randomize Colors |
 
 All shortcuts can be changed or disabled in Settings.
 

--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -169,6 +169,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             settingsStore.update { $0.showMiddleClick.toggle() }
         case .toggleShowDrag:
             settingsStore.update { $0.showDrag.toggle() }
+        case .randomizeColors:
+            settingsStore.update { $0.applyRandomizedStyle() }
         }
     }
 

--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -18,14 +18,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         onCheckForUpdates: { UpdateChecker.shared.checkForUpdates() },
         updatesAreConfigured: { UpdateChecker.shared.isConfigured },
         onOpenSettings: { [weak self] in self?.openSettings() },
-        onQuit: { NSApplication.shared.terminate(nil) },
-        onMenuWillOpen: { [weak self] in
-            self?.hotKeyManager.unregisterAll()
-        },
-        onMenuDidClose: { [weak self] in
-            guard let self else { return }
-            self.configureHotKeysIfNeeded(with: self.settingsStore.settings, force: true)
-        }
+        onQuit: { NSApplication.shared.terminate(nil) }
     )
     private let eventTap = ClickEventTap()
     private let permissions = PermissionController()

--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -169,6 +169,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             settingsStore.update { $0.showMiddleClick.toggle() }
         case .toggleShowDrag:
             settingsStore.update { $0.showDrag.toggle() }
+        case .randomizeColors:
+            settingsStore.update { $0.applyRandomizedStyle() }
         case .toggleLiveKeyboardShortcuts:
             settingsStore.update { $0.showLiveKeyboardShortcuts.toggle() }
         }

--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -18,7 +18,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         onCheckForUpdates: { UpdateChecker.shared.checkForUpdates() },
         updatesAreConfigured: { UpdateChecker.shared.isConfigured },
         onOpenSettings: { [weak self] in self?.openSettings() },
-        onQuit: { NSApplication.shared.terminate(nil) }
+        onQuit: { NSApplication.shared.terminate(nil) },
+        onMenuWillOpen: { [weak self] in
+            self?.hotKeyManager.unregisterAll()
+        },
+        onMenuDidClose: { [weak self] in
+            guard let self else { return }
+            self.configureHotKeysIfNeeded(with: self.settingsStore.settings, force: true)
+        }
     )
     private let eventTap = ClickEventTap()
     private let permissions = PermissionController()

--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -169,8 +169,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             settingsStore.update { $0.showMiddleClick.toggle() }
         case .toggleShowDrag:
             settingsStore.update { $0.showDrag.toggle() }
-        case .randomizeColors:
-            settingsStore.update { $0.applyRandomizedStyle() }
         case .toggleLiveKeyboardShortcuts:
             settingsStore.update { $0.showLiveKeyboardShortcuts.toggle() }
         }

--- a/Sources/ClickLight/HotKeyBinding.swift
+++ b/Sources/ClickLight/HotKeyBinding.swift
@@ -165,6 +165,7 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
     case toggleShowRightClick
     case toggleShowMiddleClick
     case toggleShowDrag
+    case randomizeColors
     case toggleLiveKeyboardShortcuts
 
     var id: String { rawValue }
@@ -185,6 +186,8 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
             return "Toggle Middle Click"
         case .toggleShowDrag:
             return "Toggle Drag"
+        case .randomizeColors:
+            return "Randomize Colors"
         case .toggleLiveKeyboardShortcuts:
             return "Toggle Live Keyboard Shortcuts"
         }
@@ -208,6 +211,8 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
             return 7
         case .toggleLiveKeyboardShortcuts:
             return 8
+        case .randomizeColors:
+            return 9
         }
     }
 
@@ -221,6 +226,7 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
             .toggleShowRightClick,
             .toggleShowMiddleClick,
             .toggleShowDrag,
+            .randomizeColors,
             .toggleLiveKeyboardShortcuts:
             return nil
         }

--- a/Sources/ClickLight/HotKeyBinding.swift
+++ b/Sources/ClickLight/HotKeyBinding.swift
@@ -209,7 +209,6 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
             return 6
         case .toggleShowDrag:
             return 7
-        case .randomizeColors:
         case .toggleLiveKeyboardShortcuts:
             return 8
         case .randomizeColors:

--- a/Sources/ClickLight/HotKeyBinding.swift
+++ b/Sources/ClickLight/HotKeyBinding.swift
@@ -165,6 +165,7 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
     case toggleShowRightClick
     case toggleShowMiddleClick
     case toggleShowDrag
+    case randomizeColors
 
     var id: String { rawValue }
 
@@ -184,6 +185,8 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
             return "Toggle Middle Click"
         case .toggleShowDrag:
             return "Toggle Drag"
+        case .randomizeColors:
+            return "Randomize Colors"
         }
     }
 
@@ -203,6 +206,8 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
             return 6
         case .toggleShowDrag:
             return 7
+        case .randomizeColors:
+            return 8
         }
     }
 
@@ -212,7 +217,7 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
             return HotKeyBinding(keyCode: kVK_ANSI_L, carbonModifiers: HotKeyBinding.defaultToggleModifiers)
         case .toggleLaserPointer:
             return nil
-        case .toggleShowPress, .toggleShowRelease, .toggleShowRightClick, .toggleShowMiddleClick, .toggleShowDrag:
+        case .toggleShowPress, .toggleShowRelease, .toggleShowRightClick, .toggleShowMiddleClick, .toggleShowDrag, .randomizeColors:
             return nil
         }
     }

--- a/Sources/ClickLight/HotKeyBinding.swift
+++ b/Sources/ClickLight/HotKeyBinding.swift
@@ -165,7 +165,6 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
     case toggleShowRightClick
     case toggleShowMiddleClick
     case toggleShowDrag
-    case randomizeColors
     case toggleLiveKeyboardShortcuts
 
     var id: String { rawValue }
@@ -186,8 +185,6 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
             return "Toggle Middle Click"
         case .toggleShowDrag:
             return "Toggle Drag"
-        case .randomizeColors:
-            return "Randomize Colors"
         case .toggleLiveKeyboardShortcuts:
             return "Toggle Live Keyboard Shortcuts"
         }
@@ -211,8 +208,6 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
             return 7
         case .toggleLiveKeyboardShortcuts:
             return 8
-        case .randomizeColors:
-            return 9
         }
     }
 
@@ -226,7 +221,6 @@ enum ClickShortcutAction: String, CaseIterable, Identifiable, Sendable {
             .toggleShowRightClick,
             .toggleShowMiddleClick,
             .toggleShowDrag,
-            .randomizeColors,
             .toggleLiveKeyboardShortcuts:
             return nil
         }

--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -40,6 +40,7 @@ struct ClickSettings: Equatable {
     var toggleShowRightClickHotKey: HotKeyBinding?
     var toggleShowMiddleClickHotKey: HotKeyBinding?
     var toggleShowDragHotKey: HotKeyBinding?
+    var randomizeColorsHotKey: HotKeyBinding?
 
     var customColor: NSColor {
         NSColor(
@@ -125,7 +126,8 @@ struct ClickSettings: Equatable {
         toggleShowReleaseHotKey: ClickShortcutAction.toggleShowRelease.defaultBinding,
         toggleShowRightClickHotKey: ClickShortcutAction.toggleShowRightClick.defaultBinding,
         toggleShowMiddleClickHotKey: ClickShortcutAction.toggleShowMiddleClick.defaultBinding,
-        toggleShowDragHotKey: ClickShortcutAction.toggleShowDrag.defaultBinding
+        toggleShowDragHotKey: ClickShortcutAction.toggleShowDrag.defaultBinding,
+        randomizeColorsHotKey: ClickShortcutAction.randomizeColors.defaultBinding
     )
 
     var shortcutBindings: [ClickShortcutAction: HotKeyBinding] {
@@ -150,6 +152,8 @@ struct ClickSettings: Equatable {
             return toggleShowMiddleClickHotKey
         case .toggleShowDrag:
             return toggleShowDragHotKey
+        case .randomizeColors:
+            return randomizeColorsHotKey
         }
     }
 
@@ -169,6 +173,8 @@ struct ClickSettings: Equatable {
             toggleShowMiddleClickHotKey = binding
         case .toggleShowDrag:
             toggleShowDragHotKey = binding
+        case .randomizeColors:
+            randomizeColorsHotKey = binding
         }
     }
 
@@ -188,6 +194,43 @@ struct ClickSettings: Equatable {
 
     static func defaultShortcutBinding(for action: ClickShortcutAction) -> HotKeyBinding? {
         action.defaultBinding
+    }
+
+    mutating func applyRandomizedStyle() {
+        let size = ClickSettingOptions.sizePresets.randomElement()?.value ?? Double(Self.defaults.size)
+        let intensity = ClickSettingOptions.intensityPresets.randomElement()?.value ?? Double(Self.defaults.intensity)
+        let duration = ClickSettingOptions.durationPresets.randomElement()?.value ?? Self.defaults.duration
+        let baseHue = CGFloat.random(in: 0...1)
+        let colors = [0.0, 0.23, 0.46, 0.69].shuffled().map { offset in
+            NSColor(
+                calibratedHue: (baseHue + CGFloat(offset)).truncatingRemainder(dividingBy: 1),
+                saturation: CGFloat.random(in: 0.65...0.95),
+                brightness: CGFloat.random(in: 0.75...1),
+                alpha: 1
+            )
+        }
+        let left = colors[0]
+        let right = colors[1]
+        let middle = colors[2]
+        let drag = colors[3]
+
+        self.size = CGFloat(size)
+        self.intensity = CGFloat(intensity)
+        self.duration = duration
+        self.customLeftColorRed = left.redComponent
+        self.customLeftColorGreen = left.greenComponent
+        self.customLeftColorBlue = left.blueComponent
+        self.customRightColorRed = right.redComponent
+        self.customRightColorGreen = right.greenComponent
+        self.customRightColorBlue = right.blueComponent
+        self.customMiddleColorRed = middle.redComponent
+        self.customMiddleColorGreen = middle.greenComponent
+        self.customMiddleColorBlue = middle.blueComponent
+        self.customDragColorRed = drag.redComponent
+        self.customDragColorGreen = drag.greenComponent
+        self.customDragColorBlue = drag.blueComponent
+        self.colorPreset = .custom
+        self.customColorMode = .byClick
     }
 }
 
@@ -401,6 +444,9 @@ final class SettingsStore {
         static let toggleShowDragHotKeyCode = "toggleShowDragHotKeyCode"
         static let toggleShowDragHotKeyModifiers = "toggleShowDragHotKeyModifiers"
         static let toggleShowDragHotKeyIsEnabled = "toggleShowDragHotKeyIsEnabled"
+        static let randomizeColorsHotKeyCode = "randomizeColorsHotKeyCode"
+        static let randomizeColorsHotKeyModifiers = "randomizeColorsHotKeyModifiers"
+        static let randomizeColorsHotKeyIsEnabled = "randomizeColorsHotKeyIsEnabled"
     }
 
     private let defaults: UserDefaults
@@ -479,6 +525,11 @@ final class SettingsStore {
                     keyCode: Key.toggleShowDragHotKeyCode,
                     modifiers: Key.toggleShowDragHotKeyModifiers,
                     isEnabled: Key.toggleShowDragHotKeyIsEnabled
+                ),
+                randomizeColorsHotKey: shortcutBinding(
+                    keyCode: Key.randomizeColorsHotKeyCode,
+                    modifiers: Key.randomizeColorsHotKeyModifiers,
+                    isEnabled: Key.randomizeColorsHotKeyIsEnabled
                 )
             )
         }
@@ -522,6 +573,7 @@ final class SettingsStore {
             saveShortcutBinding(newValue.toggleShowRightClickHotKey, keyCode: Key.toggleShowRightClickHotKeyCode, modifiers: Key.toggleShowRightClickHotKeyModifiers, isEnabled: Key.toggleShowRightClickHotKeyIsEnabled)
             saveShortcutBinding(newValue.toggleShowMiddleClickHotKey, keyCode: Key.toggleShowMiddleClickHotKeyCode, modifiers: Key.toggleShowMiddleClickHotKeyModifiers, isEnabled: Key.toggleShowMiddleClickHotKeyIsEnabled)
             saveShortcutBinding(newValue.toggleShowDragHotKey, keyCode: Key.toggleShowDragHotKeyCode, modifiers: Key.toggleShowDragHotKeyModifiers, isEnabled: Key.toggleShowDragHotKeyIsEnabled)
+            saveShortcutBinding(newValue.randomizeColorsHotKey, keyCode: Key.randomizeColorsHotKeyCode, modifiers: Key.randomizeColorsHotKeyModifiers, isEnabled: Key.randomizeColorsHotKeyIsEnabled)
             NotificationCenter.default.post(name: Self.didChangeNotification, object: self)
         }
     }
@@ -602,7 +654,10 @@ final class SettingsStore {
             Key.toggleShowMiddleClickHotKeyIsEnabled: false,
             Key.toggleShowDragHotKeyCode: 0,
             Key.toggleShowDragHotKeyModifiers: 0,
-            Key.toggleShowDragHotKeyIsEnabled: false
+            Key.toggleShowDragHotKeyIsEnabled: false,
+            Key.randomizeColorsHotKeyCode: 0,
+            Key.randomizeColorsHotKeyModifiers: 0,
+            Key.randomizeColorsHotKeyIsEnabled: false
         ])
     }
 }

--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -44,6 +44,7 @@ struct ClickSettings: Equatable {
     var toggleShowRightClickHotKey: HotKeyBinding?
     var toggleShowMiddleClickHotKey: HotKeyBinding?
     var toggleShowDragHotKey: HotKeyBinding?
+    var randomizeColorsHotKey: HotKeyBinding?
     var toggleLiveKeyboardShortcutsHotKey: HotKeyBinding?
 
     var customColor: NSColor {
@@ -135,6 +136,7 @@ struct ClickSettings: Equatable {
         toggleShowRightClickHotKey: ClickShortcutAction.toggleShowRightClick.defaultBinding,
         toggleShowMiddleClickHotKey: ClickShortcutAction.toggleShowMiddleClick.defaultBinding,
         toggleShowDragHotKey: ClickShortcutAction.toggleShowDrag.defaultBinding,
+        randomizeColorsHotKey: ClickShortcutAction.randomizeColors.defaultBinding,
         toggleLiveKeyboardShortcutsHotKey: ClickShortcutAction.toggleLiveKeyboardShortcuts.defaultBinding
     )
 
@@ -160,6 +162,8 @@ struct ClickSettings: Equatable {
             return toggleShowMiddleClickHotKey
         case .toggleShowDrag:
             return toggleShowDragHotKey
+        case .randomizeColors:
+            return randomizeColorsHotKey
         case .toggleLiveKeyboardShortcuts:
             return toggleLiveKeyboardShortcutsHotKey
         }
@@ -181,6 +185,8 @@ struct ClickSettings: Equatable {
             toggleShowMiddleClickHotKey = binding
         case .toggleShowDrag:
             toggleShowDragHotKey = binding
+        case .randomizeColors:
+            randomizeColorsHotKey = binding
         case .toggleLiveKeyboardShortcuts:
             toggleLiveKeyboardShortcutsHotKey = binding
         }
@@ -456,6 +462,9 @@ final class SettingsStore {
         static let toggleShowDragHotKeyCode = "toggleShowDragHotKeyCode"
         static let toggleShowDragHotKeyModifiers = "toggleShowDragHotKeyModifiers"
         static let toggleShowDragHotKeyIsEnabled = "toggleShowDragHotKeyIsEnabled"
+        static let randomizeColorsHotKeyCode = "randomizeColorsHotKeyCode"
+        static let randomizeColorsHotKeyModifiers = "randomizeColorsHotKeyModifiers"
+        static let randomizeColorsHotKeyIsEnabled = "randomizeColorsHotKeyIsEnabled"
         static let toggleLiveKeyboardShortcutsHotKeyCode = "toggleLiveKeyboardShortcutsHotKeyCode"
         static let toggleLiveKeyboardShortcutsHotKeyModifiers = "toggleLiveKeyboardShortcutsHotKeyModifiers"
         static let toggleLiveKeyboardShortcutsHotKeyIsEnabled = "toggleLiveKeyboardShortcutsHotKeyIsEnabled"
@@ -542,6 +551,11 @@ final class SettingsStore {
                     modifiers: Key.toggleShowDragHotKeyModifiers,
                     isEnabled: Key.toggleShowDragHotKeyIsEnabled
                 ),
+                randomizeColorsHotKey: shortcutBinding(
+                    keyCode: Key.randomizeColorsHotKeyCode,
+                    modifiers: Key.randomizeColorsHotKeyModifiers,
+                    isEnabled: Key.randomizeColorsHotKeyIsEnabled
+                ),
                 toggleLiveKeyboardShortcutsHotKey: shortcutBinding(
                     keyCode: Key.toggleLiveKeyboardShortcutsHotKeyCode,
                     modifiers: Key.toggleLiveKeyboardShortcutsHotKeyModifiers,
@@ -593,6 +607,7 @@ final class SettingsStore {
             saveShortcutBinding(newValue.toggleShowRightClickHotKey, keyCode: Key.toggleShowRightClickHotKeyCode, modifiers: Key.toggleShowRightClickHotKeyModifiers, isEnabled: Key.toggleShowRightClickHotKeyIsEnabled)
             saveShortcutBinding(newValue.toggleShowMiddleClickHotKey, keyCode: Key.toggleShowMiddleClickHotKeyCode, modifiers: Key.toggleShowMiddleClickHotKeyModifiers, isEnabled: Key.toggleShowMiddleClickHotKeyIsEnabled)
             saveShortcutBinding(newValue.toggleShowDragHotKey, keyCode: Key.toggleShowDragHotKeyCode, modifiers: Key.toggleShowDragHotKeyModifiers, isEnabled: Key.toggleShowDragHotKeyIsEnabled)
+            saveShortcutBinding(newValue.randomizeColorsHotKey, keyCode: Key.randomizeColorsHotKeyCode, modifiers: Key.randomizeColorsHotKeyModifiers, isEnabled: Key.randomizeColorsHotKeyIsEnabled)
             saveShortcutBinding(newValue.toggleLiveKeyboardShortcutsHotKey, keyCode: Key.toggleLiveKeyboardShortcutsHotKeyCode, modifiers: Key.toggleLiveKeyboardShortcutsHotKeyModifiers, isEnabled: Key.toggleLiveKeyboardShortcutsHotKeyIsEnabled)
             NotificationCenter.default.post(name: Self.didChangeNotification, object: self)
         }
@@ -679,6 +694,9 @@ final class SettingsStore {
             Key.toggleShowDragHotKeyCode: 0,
             Key.toggleShowDragHotKeyModifiers: 0,
             Key.toggleShowDragHotKeyIsEnabled: false,
+            Key.randomizeColorsHotKeyCode: 0,
+            Key.randomizeColorsHotKeyModifiers: 0,
+            Key.randomizeColorsHotKeyIsEnabled: false,
             Key.toggleLiveKeyboardShortcutsHotKeyCode: 0,
             Key.toggleLiveKeyboardShortcutsHotKeyModifiers: 0,
             Key.toggleLiveKeyboardShortcutsHotKeyIsEnabled: false

--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -44,7 +44,6 @@ struct ClickSettings: Equatable {
     var toggleShowRightClickHotKey: HotKeyBinding?
     var toggleShowMiddleClickHotKey: HotKeyBinding?
     var toggleShowDragHotKey: HotKeyBinding?
-    var randomizeColorsHotKey: HotKeyBinding?
     var toggleLiveKeyboardShortcutsHotKey: HotKeyBinding?
 
     var customColor: NSColor {
@@ -136,7 +135,6 @@ struct ClickSettings: Equatable {
         toggleShowRightClickHotKey: ClickShortcutAction.toggleShowRightClick.defaultBinding,
         toggleShowMiddleClickHotKey: ClickShortcutAction.toggleShowMiddleClick.defaultBinding,
         toggleShowDragHotKey: ClickShortcutAction.toggleShowDrag.defaultBinding,
-        randomizeColorsHotKey: ClickShortcutAction.randomizeColors.defaultBinding,
         toggleLiveKeyboardShortcutsHotKey: ClickShortcutAction.toggleLiveKeyboardShortcuts.defaultBinding
     )
 
@@ -162,8 +160,6 @@ struct ClickSettings: Equatable {
             return toggleShowMiddleClickHotKey
         case .toggleShowDrag:
             return toggleShowDragHotKey
-        case .randomizeColors:
-            return randomizeColorsHotKey
         case .toggleLiveKeyboardShortcuts:
             return toggleLiveKeyboardShortcutsHotKey
         }
@@ -185,8 +181,6 @@ struct ClickSettings: Equatable {
             toggleShowMiddleClickHotKey = binding
         case .toggleShowDrag:
             toggleShowDragHotKey = binding
-        case .randomizeColors:
-            randomizeColorsHotKey = binding
         case .toggleLiveKeyboardShortcuts:
             toggleLiveKeyboardShortcutsHotKey = binding
         }
@@ -462,9 +456,6 @@ final class SettingsStore {
         static let toggleShowDragHotKeyCode = "toggleShowDragHotKeyCode"
         static let toggleShowDragHotKeyModifiers = "toggleShowDragHotKeyModifiers"
         static let toggleShowDragHotKeyIsEnabled = "toggleShowDragHotKeyIsEnabled"
-        static let randomizeColorsHotKeyCode = "randomizeColorsHotKeyCode"
-        static let randomizeColorsHotKeyModifiers = "randomizeColorsHotKeyModifiers"
-        static let randomizeColorsHotKeyIsEnabled = "randomizeColorsHotKeyIsEnabled"
         static let toggleLiveKeyboardShortcutsHotKeyCode = "toggleLiveKeyboardShortcutsHotKeyCode"
         static let toggleLiveKeyboardShortcutsHotKeyModifiers = "toggleLiveKeyboardShortcutsHotKeyModifiers"
         static let toggleLiveKeyboardShortcutsHotKeyIsEnabled = "toggleLiveKeyboardShortcutsHotKeyIsEnabled"
@@ -551,11 +542,6 @@ final class SettingsStore {
                     modifiers: Key.toggleShowDragHotKeyModifiers,
                     isEnabled: Key.toggleShowDragHotKeyIsEnabled
                 ),
-                randomizeColorsHotKey: shortcutBinding(
-                    keyCode: Key.randomizeColorsHotKeyCode,
-                    modifiers: Key.randomizeColorsHotKeyModifiers,
-                    isEnabled: Key.randomizeColorsHotKeyIsEnabled
-                ),
                 toggleLiveKeyboardShortcutsHotKey: shortcutBinding(
                     keyCode: Key.toggleLiveKeyboardShortcutsHotKeyCode,
                     modifiers: Key.toggleLiveKeyboardShortcutsHotKeyModifiers,
@@ -607,7 +593,6 @@ final class SettingsStore {
             saveShortcutBinding(newValue.toggleShowRightClickHotKey, keyCode: Key.toggleShowRightClickHotKeyCode, modifiers: Key.toggleShowRightClickHotKeyModifiers, isEnabled: Key.toggleShowRightClickHotKeyIsEnabled)
             saveShortcutBinding(newValue.toggleShowMiddleClickHotKey, keyCode: Key.toggleShowMiddleClickHotKeyCode, modifiers: Key.toggleShowMiddleClickHotKeyModifiers, isEnabled: Key.toggleShowMiddleClickHotKeyIsEnabled)
             saveShortcutBinding(newValue.toggleShowDragHotKey, keyCode: Key.toggleShowDragHotKeyCode, modifiers: Key.toggleShowDragHotKeyModifiers, isEnabled: Key.toggleShowDragHotKeyIsEnabled)
-            saveShortcutBinding(newValue.randomizeColorsHotKey, keyCode: Key.randomizeColorsHotKeyCode, modifiers: Key.randomizeColorsHotKeyModifiers, isEnabled: Key.randomizeColorsHotKeyIsEnabled)
             saveShortcutBinding(newValue.toggleLiveKeyboardShortcutsHotKey, keyCode: Key.toggleLiveKeyboardShortcutsHotKeyCode, modifiers: Key.toggleLiveKeyboardShortcutsHotKeyModifiers, isEnabled: Key.toggleLiveKeyboardShortcutsHotKeyIsEnabled)
             NotificationCenter.default.post(name: Self.didChangeNotification, object: self)
         }
@@ -694,9 +679,6 @@ final class SettingsStore {
             Key.toggleShowDragHotKeyCode: 0,
             Key.toggleShowDragHotKeyModifiers: 0,
             Key.toggleShowDragHotKeyIsEnabled: false,
-            Key.randomizeColorsHotKeyCode: 0,
-            Key.randomizeColorsHotKeyModifiers: 0,
-            Key.randomizeColorsHotKeyIsEnabled: false,
             Key.toggleLiveKeyboardShortcutsHotKeyCode: 0,
             Key.toggleLiveKeyboardShortcutsHotKeyModifiers: 0,
             Key.toggleLiveKeyboardShortcutsHotKeyIsEnabled: false

--- a/Sources/ClickLight/SettingsWindowController.swift
+++ b/Sources/ClickLight/SettingsWindowController.swift
@@ -204,42 +204,7 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
     }
 
     func randomizeStyle() {
-        let size = ClickSettingOptions.sizePresets.randomElement()?.value ?? Double(ClickSettings.defaults.size)
-        let intensity = ClickSettingOptions.intensityPresets.randomElement()?.value ?? Double(ClickSettings.defaults.intensity)
-        let duration = ClickSettingOptions.durationPresets.randomElement()?.value ?? ClickSettings.defaults.duration
-        let baseHue = CGFloat.random(in: 0...1)
-        let colors = [0.0, 0.23, 0.46, 0.69].shuffled().map { offset in
-            NSColor(
-                calibratedHue: (baseHue + CGFloat(offset)).truncatingRemainder(dividingBy: 1),
-                saturation: CGFloat.random(in: 0.65...0.95),
-                brightness: CGFloat.random(in: 0.75...1),
-                alpha: 1
-            )
-        }
-        let left = colors[0]
-        let right = colors[1]
-        let middle = colors[2]
-        let drag = colors[3]
-
-        update {
-            $0.size = CGFloat(size)
-            $0.intensity = CGFloat(intensity)
-            $0.duration = duration
-            $0.customLeftColorRed = left.redComponent
-            $0.customLeftColorGreen = left.greenComponent
-            $0.customLeftColorBlue = left.blueComponent
-            $0.customRightColorRed = right.redComponent
-            $0.customRightColorGreen = right.greenComponent
-            $0.customRightColorBlue = right.blueComponent
-            $0.customMiddleColorRed = middle.redComponent
-            $0.customMiddleColorGreen = middle.greenComponent
-            $0.customMiddleColorBlue = middle.blueComponent
-            $0.customDragColorRed = drag.redComponent
-            $0.customDragColorGreen = drag.greenComponent
-            $0.customDragColorBlue = drag.blueComponent
-            $0.colorPreset = .custom
-            $0.customColorMode = .byClick
-        }
+        update { $0.applyRandomizedStyle() }
     }
 
     func applyCustomColor(_ color: NSColor) {

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -101,22 +101,19 @@ final class StatusController: NSObject {
         menu.addItem(toggleItem(
             title: "Enabled",
             isOn: settings.isEnabled,
-            action: #selector(toggleEnabled(_:)),
-            shortcut: settings.shortcutBinding(for: .toggleEnabled)
+            action: #selector(toggleEnabled(_:))
         ))
         menu.addItem(.separator())
 
         menu.addItem(toggleItem(
             title: "Laser Pointer Mode",
             isOn: settings.showLaserPointer,
-            action: #selector(toggleLaserPointer(_:)),
-            shortcut: settings.shortcutBinding(for: .toggleLaserPointer)
+            action: #selector(toggleLaserPointer(_:))
         ))
         menu.addItem(toggleItem(
             title: "Show Live Keyboard Shortcuts",
             isOn: settings.showLiveKeyboardShortcuts,
-            action: #selector(toggleLiveKeyboardShortcuts(_:)),
-            shortcut: settings.shortcutBinding(for: .toggleLiveKeyboardShortcuts)
+            action: #selector(toggleLiveKeyboardShortcuts(_:))
         ))
         menu.addItem(.separator())
 
@@ -124,32 +121,27 @@ final class StatusController: NSObject {
             menu.addItem(toggleItem(
                 title: "Show Press",
                 isOn: settings.showPress,
-                action: #selector(togglePress(_:)),
-                shortcut: settings.shortcutBinding(for: .toggleShowPress)
+                action: #selector(togglePress(_:))
             ))
             menu.addItem(toggleItem(
                 title: "Show Release",
                 isOn: settings.showRelease,
-                action: #selector(toggleRelease(_:)),
-                shortcut: settings.shortcutBinding(for: .toggleShowRelease)
+                action: #selector(toggleRelease(_:))
             ))
             menu.addItem(toggleItem(
                 title: "Show Right Click",
                 isOn: settings.showRightClick,
-                action: #selector(toggleRightClick(_:)),
-                shortcut: settings.shortcutBinding(for: .toggleShowRightClick)
+                action: #selector(toggleRightClick(_:))
             ))
             menu.addItem(toggleItem(
                 title: "Show Middle Click",
                 isOn: settings.showMiddleClick,
-                action: #selector(toggleMiddleClick(_:)),
-                shortcut: settings.shortcutBinding(for: .toggleShowMiddleClick)
+                action: #selector(toggleMiddleClick(_:))
             ))
             let showDragItem = toggleItem(
                 title: "Show Drag",
                 isOn: settings.showDrag,
-                action: #selector(toggleDrag(_:)),
-                shortcut: settings.shortcutBinding(for: .toggleShowDrag)
+                action: #selector(toggleDrag(_:))
             )
             showDragItem.isEnabled = !settings.showLaserPointer
             menu.addItem(showDragItem)
@@ -175,7 +167,7 @@ final class StatusController: NSObject {
                 selected: settings.duration,
                 action: #selector(selectDuration(_:))
             ))
-            menu.addItem(colorSubmenu(selected: settings.colorPreset, randomizeShortcut: settings.shortcutBinding(for: .randomizeColors)))
+            menu.addItem(colorSubmenu(selected: settings.colorPreset))
             menu.addItem(.separator())
         }
 
@@ -259,25 +251,12 @@ final class StatusController: NSObject {
     private func toggleItem(
         title: String,
         isOn: Bool,
-        action: Selector,
-        shortcut: HotKeyBinding? = nil
+        action: Selector
     ) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = self
         item.state = isOn ? .on : .off
-        applyShortcut(shortcut, to: item)
         return item
-    }
-
-    private func applyShortcut(_ shortcut: HotKeyBinding?, to item: NSMenuItem) {
-        item.attributedTitle = nil
-        guard let shortcut, let keyEquivalent = shortcut.menuKeyEquivalent else {
-            item.keyEquivalent = ""
-            item.keyEquivalentModifierMask = []
-            return
-        }
-        item.keyEquivalent = keyEquivalent
-        item.keyEquivalentModifierMask = shortcut.menuModifierFlags
     }
 
     private func submenu(
@@ -307,7 +286,7 @@ final class StatusController: NSObject {
         return item
     }
 
-    private func colorSubmenu(selected: ClickColorPreset, randomizeShortcut: HotKeyBinding?) -> NSMenuItem {
+    private func colorSubmenu(selected: ClickColorPreset) -> NSMenuItem {
         let item = NSMenuItem(title: "Colors", action: nil, keyEquivalent: "")
         let menu = NSMenu()
         for preset in ClickColorPreset.allCases where preset != .custom {
@@ -334,7 +313,6 @@ final class StatusController: NSObject {
 
         let randomize = NSMenuItem(title: "Randomize Colors", action: #selector(randomizeColors(_:)), keyEquivalent: "")
         randomize.target = self
-        applyShortcut(randomizeShortcut, to: randomize)
         menu.addItem(randomize)
 
         item.submenu = menu

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -187,7 +187,7 @@ final class StatusController: NSObject {
             selected: settings.duration,
             action: #selector(selectDuration(_:))
         ))
-        menu.addItem(colorSubmenu(selected: settings.colorPreset))
+        menu.addItem(colorSubmenu(selected: settings.colorPreset, randomizeShortcut: settings.shortcutBindings[.randomizeColors]))
         menu.addItem(NSMenuItem.separator())
 
         let openSettingsItem = NSMenuItem(title: "Open Settings...", action: #selector(openSettings), keyEquivalent: ",")
@@ -295,7 +295,7 @@ final class StatusController: NSObject {
         return item
     }
 
-    private func colorSubmenu(selected: ClickColorPreset) -> NSMenuItem {
+    private func colorSubmenu(selected: ClickColorPreset, randomizeShortcut: HotKeyBinding?) -> NSMenuItem {
         let item = NSMenuItem(title: "Colors", action: nil, keyEquivalent: "")
         let menu = NSMenu()
         for preset in ClickColorPreset.allCases where preset != .custom {
@@ -318,6 +318,12 @@ final class StatusController: NSObject {
         let configureCustom = NSMenuItem(title: "Configure Custom Colors...", action: #selector(openSettings), keyEquivalent: "")
         configureCustom.target = self
         menu.addItem(configureCustom)
+        menu.addItem(NSMenuItem.separator())
+
+        let randomize = NSMenuItem(title: "Randomize Colors", action: #selector(randomizeColors(_:)), keyEquivalent: "")
+        randomize.target = self
+        applyShortcut(randomizeShortcut, to: randomize)
+        menu.addItem(randomize)
 
         item.submenu = menu
         return item
@@ -406,6 +412,11 @@ final class StatusController: NSObject {
             let preset = ClickColorPreset(rawValue: rawValue)
         else { return }
         settingsStore.update { $0.colorPreset = preset }
+    }
+
+    @objc private func randomizeColors(_ sender: NSMenuItem) {
+        dismissMenu(from: sender)
+        settingsStore.update { $0.applyRandomizedStyle() }
     }
 
     @objc private func openAccessibilitySettings() {

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -101,19 +101,22 @@ final class StatusController: NSObject {
         menu.addItem(toggleItem(
             title: "Enabled",
             isOn: settings.isEnabled,
-            action: #selector(toggleEnabled(_:))
+            action: #selector(toggleEnabled(_:)),
+            shortcut: settings.shortcutBinding(for: .toggleEnabled)
         ))
         menu.addItem(.separator())
 
         menu.addItem(toggleItem(
             title: "Laser Pointer Mode",
             isOn: settings.showLaserPointer,
-            action: #selector(toggleLaserPointer(_:))
+            action: #selector(toggleLaserPointer(_:)),
+            shortcut: settings.shortcutBinding(for: .toggleLaserPointer)
         ))
         menu.addItem(toggleItem(
             title: "Show Live Keyboard Shortcuts",
             isOn: settings.showLiveKeyboardShortcuts,
-            action: #selector(toggleLiveKeyboardShortcuts(_:))
+            action: #selector(toggleLiveKeyboardShortcuts(_:)),
+            shortcut: settings.shortcutBinding(for: .toggleLiveKeyboardShortcuts)
         ))
         menu.addItem(.separator())
 
@@ -121,27 +124,32 @@ final class StatusController: NSObject {
             menu.addItem(toggleItem(
                 title: "Show Press",
                 isOn: settings.showPress,
-                action: #selector(togglePress(_:))
+                action: #selector(togglePress(_:)),
+                shortcut: settings.shortcutBinding(for: .toggleShowPress)
             ))
             menu.addItem(toggleItem(
                 title: "Show Release",
                 isOn: settings.showRelease,
-                action: #selector(toggleRelease(_:))
+                action: #selector(toggleRelease(_:)),
+                shortcut: settings.shortcutBinding(for: .toggleShowRelease)
             ))
             menu.addItem(toggleItem(
                 title: "Show Right Click",
                 isOn: settings.showRightClick,
-                action: #selector(toggleRightClick(_:))
+                action: #selector(toggleRightClick(_:)),
+                shortcut: settings.shortcutBinding(for: .toggleShowRightClick)
             ))
             menu.addItem(toggleItem(
                 title: "Show Middle Click",
                 isOn: settings.showMiddleClick,
-                action: #selector(toggleMiddleClick(_:))
+                action: #selector(toggleMiddleClick(_:)),
+                shortcut: settings.shortcutBinding(for: .toggleShowMiddleClick)
             ))
             let showDragItem = toggleItem(
                 title: "Show Drag",
                 isOn: settings.showDrag,
-                action: #selector(toggleDrag(_:))
+                action: #selector(toggleDrag(_:)),
+                shortcut: settings.shortcutBinding(for: .toggleShowDrag)
             )
             showDragItem.isEnabled = !settings.showLaserPointer
             menu.addItem(showDragItem)
@@ -251,12 +259,25 @@ final class StatusController: NSObject {
     private func toggleItem(
         title: String,
         isOn: Bool,
-        action: Selector
+        action: Selector,
+        shortcut: HotKeyBinding? = nil
     ) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = self
         item.state = isOn ? .on : .off
+        applyShortcut(shortcut, to: item)
         return item
+    }
+
+    private func applyShortcut(_ shortcut: HotKeyBinding?, to item: NSMenuItem) {
+        item.attributedTitle = nil
+        guard let shortcut, let keyEquivalent = shortcut.menuKeyEquivalent else {
+            item.keyEquivalent = ""
+            item.keyEquivalentModifierMask = []
+            return
+        }
+        item.keyEquivalent = keyEquivalent
+        item.keyEquivalentModifierMask = shortcut.menuModifierFlags
     }
 
     private func submenu(
@@ -309,11 +330,6 @@ final class StatusController: NSObject {
         let configureCustom = NSMenuItem(title: "Configure Custom Colors...", action: #selector(openSettings), keyEquivalent: "")
         configureCustom.target = self
         menu.addItem(configureCustom)
-        menu.addItem(NSMenuItem.separator())
-
-        let randomize = NSMenuItem(title: "Randomize Colors", action: #selector(randomizeColors(_:)), keyEquivalent: "")
-        randomize.target = self
-        menu.addItem(randomize)
 
         item.submenu = menu
         return item

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -420,11 +420,6 @@ final class StatusController: NSObject {
         settingsStore.update { $0.colorPreset = preset }
     }
 
-    @objc private func randomizeColors(_ sender: NSMenuItem) {
-        dismissMenu(from: sender)
-        settingsStore.update { $0.applyRandomizedStyle() }
-    }
-
     @objc private func openAccessibilitySettings() {
         permissions.requestAccessibilityIfNeeded()
         permissions.openPrivacySettings()

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -12,8 +12,6 @@ final class StatusController: NSObject {
     private let updatesAreConfigured: () -> Bool
     private let onOpenSettings: () -> Void
     private let onQuit: () -> Void
-    private let onMenuWillOpen: () -> Void
-    private let onMenuDidClose: () -> Void
     private var activityObserver: AnyCancellable?
 
     init(
@@ -24,9 +22,7 @@ final class StatusController: NSObject {
         onCheckForUpdates: @escaping () -> Void,
         updatesAreConfigured: @escaping () -> Bool,
         onOpenSettings: @escaping () -> Void,
-        onQuit: @escaping () -> Void,
-        onMenuWillOpen: @escaping () -> Void = {},
-        onMenuDidClose: @escaping () -> Void = {}
+        onQuit: @escaping () -> Void
     ) {
         self.settingsStore = settingsStore
         self.activityStore = activityStore
@@ -36,8 +32,6 @@ final class StatusController: NSObject {
         self.updatesAreConfigured = updatesAreConfigured
         self.onOpenSettings = onOpenSettings
         self.onQuit = onQuit
-        self.onMenuWillOpen = onMenuWillOpen
-        self.onMenuDidClose = onMenuDidClose
         super.init()
     }
 
@@ -101,16 +95,14 @@ final class StatusController: NSObject {
         menu.addItem(toggleItem(
             title: "Enabled",
             isOn: settings.isEnabled,
-            action: #selector(toggleEnabled(_:)),
-            shortcut: settings.shortcutBindings[.toggleEnabled]
+            action: #selector(toggleEnabled(_:))
         ))
         menu.addItem(NSMenuItem.separator())
 
         menu.addItem(toggleItem(
             title: "Laser Pointer Mode",
             isOn: settings.showLaserPointer,
-            action: #selector(toggleLaserPointer(_:)),
-            shortcut: settings.shortcutBindings[.toggleLaserPointer]
+            action: #selector(toggleLaserPointer(_:))
         ))
         menu.addItem(toggleItem(
             title: "Show Live Keyboard Shortcuts",
@@ -122,32 +114,27 @@ final class StatusController: NSObject {
         menu.addItem(toggleItem(
             title: "Show Press",
             isOn: settings.showPress,
-            action: #selector(togglePress(_:)),
-            shortcut: settings.shortcutBindings[.toggleShowPress]
+            action: #selector(togglePress(_:))
         ))
         menu.addItem(toggleItem(
             title: "Show Release",
             isOn: settings.showRelease,
-            action: #selector(toggleRelease(_:)),
-            shortcut: settings.shortcutBindings[.toggleShowRelease]
+            action: #selector(toggleRelease(_:))
         ))
         menu.addItem(toggleItem(
             title: "Show Right Click",
             isOn: settings.showRightClick,
-            action: #selector(toggleRightClick(_:)),
-            shortcut: settings.shortcutBindings[.toggleShowRightClick]
+            action: #selector(toggleRightClick(_:))
         ))
         menu.addItem(toggleItem(
             title: "Show Middle Click",
             isOn: settings.showMiddleClick,
-            action: #selector(toggleMiddleClick(_:)),
-            shortcut: settings.shortcutBindings[.toggleShowMiddleClick]
+            action: #selector(toggleMiddleClick(_:))
         ))
         let showDragItem = toggleItem(
             title: "Show Drag",
             isOn: settings.showDrag,
-            action: #selector(toggleDrag(_:)),
-            shortcut: settings.shortcutBindings[.toggleShowDrag]
+            action: #selector(toggleDrag(_:))
         )
         showDragItem.isEnabled = !settings.showLaserPointer
         menu.addItem(showDragItem)
@@ -187,7 +174,7 @@ final class StatusController: NSObject {
             selected: settings.duration,
             action: #selector(selectDuration(_:))
         ))
-        menu.addItem(colorSubmenu(selected: settings.colorPreset, randomizeShortcut: settings.shortcutBindings[.randomizeColors]))
+        menu.addItem(colorSubmenu(selected: settings.colorPreset))
         menu.addItem(NSMenuItem.separator())
 
         let openSettingsItem = NSMenuItem(title: "Open Settings...", action: #selector(openSettings), keyEquivalent: ",")
@@ -247,25 +234,12 @@ final class StatusController: NSObject {
     private func toggleItem(
         title: String,
         isOn: Bool,
-        action: Selector,
-        shortcut: HotKeyBinding? = nil
+        action: Selector
     ) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = self
         item.state = isOn ? .on : .off
-        applyShortcut(shortcut, to: item)
         return item
-    }
-
-    private func applyShortcut(_ shortcut: HotKeyBinding?, to item: NSMenuItem) {
-        item.attributedTitle = nil
-        guard let shortcut, let keyEquivalent = shortcut.menuKeyEquivalent else {
-            item.keyEquivalent = ""
-            item.keyEquivalentModifierMask = []
-            return
-        }
-        item.keyEquivalent = keyEquivalent
-        item.keyEquivalentModifierMask = shortcut.menuModifierFlags
     }
 
     private func submenu(
@@ -295,7 +269,7 @@ final class StatusController: NSObject {
         return item
     }
 
-    private func colorSubmenu(selected: ClickColorPreset, randomizeShortcut: HotKeyBinding?) -> NSMenuItem {
+    private func colorSubmenu(selected: ClickColorPreset) -> NSMenuItem {
         let item = NSMenuItem(title: "Colors", action: nil, keyEquivalent: "")
         let menu = NSMenu()
         for preset in ClickColorPreset.allCases where preset != .custom {
@@ -322,7 +296,6 @@ final class StatusController: NSObject {
 
         let randomize = NSMenuItem(title: "Randomize Colors", action: #selector(randomizeColors(_:)), keyEquivalent: "")
         randomize.target = self
-        applyShortcut(randomizeShortcut, to: randomize)
         menu.addItem(randomize)
 
         item.submenu = menu
@@ -452,18 +425,6 @@ final class StatusController: NSObject {
 }
 
 extension StatusController: NSMenuDelegate {
-    nonisolated func menuWillOpen(_ menu: NSMenu) {
-        MainActor.assumeIsolated {
-            onMenuWillOpen()
-        }
-    }
-
-    nonisolated func menuDidClose(_ menu: NSMenu) {
-        MainActor.assumeIsolated {
-            onMenuDidClose()
-        }
-    }
-
     nonisolated func menuNeedsUpdate(_ menu: NSMenu) {
         MainActor.assumeIsolated {
             // Refresh the existing menu instance. Replacing statusItem.menu

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -12,6 +12,8 @@ final class StatusController: NSObject {
     private let updatesAreConfigured: () -> Bool
     private let onOpenSettings: () -> Void
     private let onQuit: () -> Void
+    private let onMenuWillOpen: () -> Void
+    private let onMenuDidClose: () -> Void
     private var activityObserver: AnyCancellable?
 
     init(
@@ -22,7 +24,9 @@ final class StatusController: NSObject {
         onCheckForUpdates: @escaping () -> Void,
         updatesAreConfigured: @escaping () -> Bool,
         onOpenSettings: @escaping () -> Void,
-        onQuit: @escaping () -> Void
+        onQuit: @escaping () -> Void,
+        onMenuWillOpen: @escaping () -> Void = {},
+        onMenuDidClose: @escaping () -> Void = {}
     ) {
         self.settingsStore = settingsStore
         self.activityStore = activityStore
@@ -32,6 +36,8 @@ final class StatusController: NSObject {
         self.updatesAreConfigured = updatesAreConfigured
         self.onOpenSettings = onOpenSettings
         self.onQuit = onQuit
+        self.onMenuWillOpen = onMenuWillOpen
+        self.onMenuDidClose = onMenuDidClose
         super.init()
     }
 
@@ -95,14 +101,16 @@ final class StatusController: NSObject {
         menu.addItem(toggleItem(
             title: "Enabled",
             isOn: settings.isEnabled,
-            action: #selector(toggleEnabled(_:))
+            action: #selector(toggleEnabled(_:)),
+            shortcut: settings.shortcutBindings[.toggleEnabled]
         ))
         menu.addItem(NSMenuItem.separator())
 
         menu.addItem(toggleItem(
             title: "Laser Pointer Mode",
             isOn: settings.showLaserPointer,
-            action: #selector(toggleLaserPointer(_:))
+            action: #selector(toggleLaserPointer(_:)),
+            shortcut: settings.shortcutBindings[.toggleLaserPointer]
         ))
         menu.addItem(toggleItem(
             title: "Show Live Keyboard Shortcuts",
@@ -114,27 +122,32 @@ final class StatusController: NSObject {
         menu.addItem(toggleItem(
             title: "Show Press",
             isOn: settings.showPress,
-            action: #selector(togglePress(_:))
+            action: #selector(togglePress(_:)),
+            shortcut: settings.shortcutBindings[.toggleShowPress]
         ))
         menu.addItem(toggleItem(
             title: "Show Release",
             isOn: settings.showRelease,
-            action: #selector(toggleRelease(_:))
+            action: #selector(toggleRelease(_:)),
+            shortcut: settings.shortcutBindings[.toggleShowRelease]
         ))
         menu.addItem(toggleItem(
             title: "Show Right Click",
             isOn: settings.showRightClick,
-            action: #selector(toggleRightClick(_:))
+            action: #selector(toggleRightClick(_:)),
+            shortcut: settings.shortcutBindings[.toggleShowRightClick]
         ))
         menu.addItem(toggleItem(
             title: "Show Middle Click",
             isOn: settings.showMiddleClick,
-            action: #selector(toggleMiddleClick(_:))
+            action: #selector(toggleMiddleClick(_:)),
+            shortcut: settings.shortcutBindings[.toggleShowMiddleClick]
         ))
         let showDragItem = toggleItem(
             title: "Show Drag",
             isOn: settings.showDrag,
-            action: #selector(toggleDrag(_:))
+            action: #selector(toggleDrag(_:)),
+            shortcut: settings.shortcutBindings[.toggleShowDrag]
         )
         showDragItem.isEnabled = !settings.showLaserPointer
         menu.addItem(showDragItem)
@@ -174,7 +187,7 @@ final class StatusController: NSObject {
             selected: settings.duration,
             action: #selector(selectDuration(_:))
         ))
-        menu.addItem(colorSubmenu(selected: settings.colorPreset))
+        menu.addItem(colorSubmenu(selected: settings.colorPreset, randomizeShortcut: settings.shortcutBindings[.randomizeColors]))
         menu.addItem(NSMenuItem.separator())
 
         let openSettingsItem = NSMenuItem(title: "Open Settings...", action: #selector(openSettings), keyEquivalent: ",")
@@ -234,12 +247,25 @@ final class StatusController: NSObject {
     private func toggleItem(
         title: String,
         isOn: Bool,
-        action: Selector
+        action: Selector,
+        shortcut: HotKeyBinding? = nil
     ) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = self
         item.state = isOn ? .on : .off
+        applyShortcut(shortcut, to: item)
         return item
+    }
+
+    private func applyShortcut(_ shortcut: HotKeyBinding?, to item: NSMenuItem) {
+        item.attributedTitle = nil
+        guard let shortcut, let keyEquivalent = shortcut.menuKeyEquivalent else {
+            item.keyEquivalent = ""
+            item.keyEquivalentModifierMask = []
+            return
+        }
+        item.keyEquivalent = keyEquivalent
+        item.keyEquivalentModifierMask = shortcut.menuModifierFlags
     }
 
     private func submenu(
@@ -269,7 +295,7 @@ final class StatusController: NSObject {
         return item
     }
 
-    private func colorSubmenu(selected: ClickColorPreset) -> NSMenuItem {
+    private func colorSubmenu(selected: ClickColorPreset, randomizeShortcut: HotKeyBinding?) -> NSMenuItem {
         let item = NSMenuItem(title: "Colors", action: nil, keyEquivalent: "")
         let menu = NSMenu()
         for preset in ClickColorPreset.allCases where preset != .custom {
@@ -296,6 +322,7 @@ final class StatusController: NSObject {
 
         let randomize = NSMenuItem(title: "Randomize Colors", action: #selector(randomizeColors(_:)), keyEquivalent: "")
         randomize.target = self
+        applyShortcut(randomizeShortcut, to: randomize)
         menu.addItem(randomize)
 
         item.submenu = menu
@@ -425,6 +452,18 @@ final class StatusController: NSObject {
 }
 
 extension StatusController: NSMenuDelegate {
+    nonisolated func menuWillOpen(_ menu: NSMenu) {
+        MainActor.assumeIsolated {
+            onMenuWillOpen()
+        }
+    }
+
+    nonisolated func menuDidClose(_ menu: NSMenu) {
+        MainActor.assumeIsolated {
+            onMenuDidClose()
+        }
+    }
+
     nonisolated func menuNeedsUpdate(_ menu: NSMenu) {
         MainActor.assumeIsolated {
             // Refresh the existing menu instance. Replacing statusItem.menu


### PR DESCRIPTION
## Summary
- keeps Randomize Colors as an assignable keyboard shortcut
- reuses the Settings randomizer through shared style-randomization logic
- removes the menu-bar randomize action so the status menu stays focused

## Testing
- Built locally with `./build-app.sh`