### PR TITLE
Add laser pointer color customization

### DIFF
--- a/Sources/ClickLight/ClickLightSettingsView.swift
+++ b/Sources/ClickLight/ClickLightSettingsView.swift
@@ -482,7 +482,7 @@ struct ClickLightSettingsView: View {
         SettingsCard {
             VStack(spacing: 0) {
                 ModernRow(title: "Laser Pointer Mode",
-                          subtitle: "Show a fading red pointer and draw temporary strokes while dragging.") {
+                          subtitle: "Show a fading pointer and draw temporary strokes while dragging.") {
                     Toggle("", isOn: binding(\.showLaserPointer))
                         .toggleStyle(.switch)
                         .labelsHidden()

--- a/Sources/ClickLight/ClickLightSettingsView.swift
+++ b/Sources/ClickLight/ClickLightSettingsView.swift
@@ -113,6 +113,21 @@ struct ClickLightSettingsView: View {
         )
     }
 
+    private func laserColorPicker(title: String, color: Binding<Color>) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            ColorPicker(
+                title,
+                selection: color,
+                supportsOpacity: false
+            )
+            .labelsHidden()
+            .accessibilityLabel("Laser Pointer \(title) Color")
+        }
+    }
+
     // MARK: - Pane Header
 
     private var paneHeader: some View {
@@ -434,6 +449,28 @@ struct ClickLightSettingsView: View {
                             )
                             .labelsHidden()
                             .accessibilityLabel("Custom Color Picker")
+                        }
+                    }
+
+                    Divider()
+
+                    ModernRow(title: "Laser Pointer Color",
+                              subtitle: "Outer ring and inner fill. The middle color is blended automatically.") {
+                        HStack(spacing: 12) {
+                            laserColorPicker(
+                                title: "Outer",
+                                color: Binding(
+                                    get: { Color(nsColor: viewModel.settings.laserColor) },
+                                    set: { viewModel.applyLaserColor(NSColor($0)) }
+                                )
+                            )
+                            laserColorPicker(
+                                title: "Inner",
+                                color: Binding(
+                                    get: { Color(nsColor: viewModel.settings.laserInnerColor) },
+                                    set: { viewModel.applyLaserInnerColor(NSColor($0)) }
+                                )
+                            )
                         }
                     }
                 }

--- a/Sources/ClickLight/ClickOverlayView.swift
+++ b/Sources/ClickLight/ClickOverlayView.swift
@@ -162,18 +162,26 @@ final class ClickOverlayView: NSView {
 
         guard let laserCursor, !laserCursor.isExpired(at: now) else { return }
         let alpha = laserCursor.alpha(at: now)
-        let laserColor = NSColor(calibratedRed: 1.0, green: 0.16, blue: 0.24, alpha: 1)
+        let laserColor = settings.laserColor
+        let middleColor = settings.laserMiddleColor
+        let innerColor = settings.laserInnerColor
         context.saveGState()
         context.setFillColor(laserColor.withAlphaComponent(alpha * 0.18).cgColor)
-        context.fillEllipse(in: CGRect(x: laserCursor.point.x - 14, y: laserCursor.point.y - 14, width: 28, height: 28))
+        context.fillEllipse(in: CGRect(x: laserCursor.point.x - 16, y: laserCursor.point.y - 16, width: 32, height: 32))
         context.setFillColor(laserColor.withAlphaComponent(alpha).cgColor)
-        context.fillEllipse(in: CGRect(x: laserCursor.point.x - 6, y: laserCursor.point.y - 6, width: 12, height: 12))
+        context.fillEllipse(in: CGRect(x: laserCursor.point.x - 8, y: laserCursor.point.y - 8, width: 16, height: 16))
+        context.setFillColor(middleColor.withAlphaComponent(alpha).cgColor)
+        context.fillEllipse(in: CGRect(x: laserCursor.point.x - 6.5, y: laserCursor.point.y - 6.5, width: 13, height: 13))
+        context.setFillColor(innerColor.withAlphaComponent(alpha).cgColor)
+        context.fillEllipse(in: CGRect(x: laserCursor.point.x - 5.5, y: laserCursor.point.y - 5.5, width: 11, height: 11))
         context.restoreGState()
     }
 
     private func drawLaserStroke(_ stroke: LaserStroke, alpha: CGFloat, in context: CGContext) {
         guard stroke.points.count >= 2, alpha > 0 else { return }
-        let laserColor = NSColor(calibratedRed: 1.0, green: 0.16, blue: 0.24, alpha: 1)
+        let laserColor = settings.laserColor
+        let middleColor = settings.laserMiddleColor
+        let innerColor = settings.laserInnerColor
         context.saveGState()
         context.setLineCap(.round)
         context.setLineJoin(.round)
@@ -191,7 +199,17 @@ final class ClickOverlayView: NSView {
 
         context.addPath(path)
         context.setStrokeColor(laserColor.withAlphaComponent(alpha).cgColor)
-        context.setLineWidth(5)
+        context.setLineWidth(6)
+        context.strokePath()
+
+        context.addPath(path)
+        context.setStrokeColor(middleColor.withAlphaComponent(alpha).cgColor)
+        context.setLineWidth(4)
+        context.strokePath()
+
+        context.addPath(path)
+        context.setStrokeColor(innerColor.withAlphaComponent(alpha).cgColor)
+        context.setLineWidth(2)
         context.strokePath()
         context.restoreGState()
     }

--- a/Sources/ClickLight/SettingsStore.swift
+++ b/Sources/ClickLight/SettingsStore.swift
@@ -37,6 +37,12 @@ struct ClickSettings: Equatable {
     var customDragColorRed: CGFloat
     var customDragColorGreen: CGFloat
     var customDragColorBlue: CGFloat
+    var laserColorRed: CGFloat
+    var laserColorGreen: CGFloat
+    var laserColorBlue: CGFloat
+    var laserInnerColorRed: CGFloat
+    var laserInnerColorGreen: CGFloat
+    var laserInnerColorBlue: CGFloat
     var toggleEnabledHotKey: HotKeyBinding?
     var toggleLaserPointerHotKey: HotKeyBinding?
     var toggleShowPressHotKey: HotKeyBinding?
@@ -91,6 +97,33 @@ struct ClickSettings: Equatable {
         )
     }
 
+    var laserColor: NSColor {
+        NSColor(
+            calibratedRed: laserColorRed.sanitizedColorComponent,
+            green: laserColorGreen.sanitizedColorComponent,
+            blue: laserColorBlue.sanitizedColorComponent,
+            alpha: 1
+        )
+    }
+
+    var laserInnerColor: NSColor {
+        NSColor(
+            calibratedRed: laserInnerColorRed.sanitizedColorComponent,
+            green: laserInnerColorGreen.sanitizedColorComponent,
+            blue: laserInnerColorBlue.sanitizedColorComponent,
+            alpha: 1
+        )
+    }
+
+    var laserMiddleColor: NSColor {
+        NSColor(
+            calibratedRed: ((laserColorRed + laserInnerColorRed) / 2).sanitizedColorComponent,
+            green: ((laserColorGreen + laserInnerColorGreen) / 2).sanitizedColorComponent,
+            blue: ((laserColorBlue + laserInnerColorBlue) / 2).sanitizedColorComponent,
+            alpha: 1
+        )
+    }
+
     static let defaults = ClickSettings(
         isEnabled: true,
         showPress: true,
@@ -128,6 +161,12 @@ struct ClickSettings: Equatable {
         customDragColorRed: 0.92,
         customDragColorGreen: 0.84,
         customDragColorBlue: 0.22,
+        laserColorRed: 1.0,
+        laserColorGreen: 0.1607843137,
+        laserColorBlue: 0.0196078431,
+        laserInnerColorRed: 1.0,
+        laserInnerColorGreen: 1.0,
+        laserInnerColorBlue: 1.0,
         toggleEnabledHotKey: ClickShortcutAction.toggleEnabled.defaultBinding,
         toggleLaserPointerHotKey: ClickShortcutAction.toggleLaserPointer.defaultBinding,
         toggleShowPressHotKey: ClickShortcutAction.toggleShowPress.defaultBinding,
@@ -394,6 +433,12 @@ final class SettingsStore {
         static let customDragColorRed = "customDragColorRed"
         static let customDragColorGreen = "customDragColorGreen"
         static let customDragColorBlue = "customDragColorBlue"
+        static let laserColorRed = "laserColorRed"
+        static let laserColorGreen = "laserColorGreen"
+        static let laserColorBlue = "laserColorBlue"
+        static let laserInnerColorRed = "laserInnerColorRed"
+        static let laserInnerColorGreen = "laserInnerColorGreen"
+        static let laserInnerColorBlue = "laserInnerColorBlue"
         static let showEventControlsInMenu = "showEventControlsInMenu"
         static let showStyleControlsInMenu = "showStyleControlsInMenu"
         static let showMenuBarControlsInMenu = "showMenuBarControlsInMenu"
@@ -470,6 +515,12 @@ final class SettingsStore {
                 customDragColorRed: CGFloat(defaults.double(forKey: Key.customDragColorRed)).sanitizedColorComponent,
                 customDragColorGreen: CGFloat(defaults.double(forKey: Key.customDragColorGreen)).sanitizedColorComponent,
                 customDragColorBlue: CGFloat(defaults.double(forKey: Key.customDragColorBlue)).sanitizedColorComponent,
+                laserColorRed: CGFloat(defaults.double(forKey: Key.laserColorRed)).sanitizedColorComponent,
+                laserColorGreen: CGFloat(defaults.double(forKey: Key.laserColorGreen)).sanitizedColorComponent,
+                laserColorBlue: CGFloat(defaults.double(forKey: Key.laserColorBlue)).sanitizedColorComponent,
+                laserInnerColorRed: CGFloat(defaults.double(forKey: Key.laserInnerColorRed)).sanitizedColorComponent,
+                laserInnerColorGreen: CGFloat(defaults.double(forKey: Key.laserInnerColorGreen)).sanitizedColorComponent,
+                laserInnerColorBlue: CGFloat(defaults.double(forKey: Key.laserInnerColorBlue)).sanitizedColorComponent,
                 toggleEnabledHotKey: shortcutBinding(
                     keyCode: Key.toggleEnabledHotKeyCode,
                     modifiers: Key.toggleEnabledHotKeyModifiers,
@@ -549,6 +600,12 @@ final class SettingsStore {
             defaults.set(Double(newValue.customDragColorRed), forKey: Key.customDragColorRed)
             defaults.set(Double(newValue.customDragColorGreen), forKey: Key.customDragColorGreen)
             defaults.set(Double(newValue.customDragColorBlue), forKey: Key.customDragColorBlue)
+            defaults.set(Double(newValue.laserColorRed), forKey: Key.laserColorRed)
+            defaults.set(Double(newValue.laserColorGreen), forKey: Key.laserColorGreen)
+            defaults.set(Double(newValue.laserColorBlue), forKey: Key.laserColorBlue)
+            defaults.set(Double(newValue.laserInnerColorRed), forKey: Key.laserInnerColorRed)
+            defaults.set(Double(newValue.laserInnerColorGreen), forKey: Key.laserInnerColorGreen)
+            defaults.set(Double(newValue.laserInnerColorBlue), forKey: Key.laserInnerColorBlue)
             saveShortcutBinding(newValue.toggleEnabledHotKey, keyCode: Key.toggleEnabledHotKeyCode, modifiers: Key.toggleEnabledHotKeyModifiers, isEnabled: Key.toggleEnabledHotKeyIsEnabled)
             saveShortcutBinding(newValue.toggleLaserPointerHotKey, keyCode: Key.toggleLaserPointerHotKeyCode, modifiers: Key.toggleLaserPointerHotKeyModifiers, isEnabled: Key.toggleLaserPointerHotKeyIsEnabled)
             saveShortcutBinding(newValue.toggleShowPressHotKey, keyCode: Key.toggleShowPressHotKeyCode, modifiers: Key.toggleShowPressHotKeyModifiers, isEnabled: Key.toggleShowPressHotKeyIsEnabled)
@@ -621,6 +678,12 @@ final class SettingsStore {
             Key.customDragColorRed: Double(defaults.customDragColorRed),
             Key.customDragColorGreen: Double(defaults.customDragColorGreen),
             Key.customDragColorBlue: Double(defaults.customDragColorBlue),
+            Key.laserColorRed: Double(defaults.laserColorRed),
+            Key.laserColorGreen: Double(defaults.laserColorGreen),
+            Key.laserColorBlue: Double(defaults.laserColorBlue),
+            Key.laserInnerColorRed: Double(defaults.laserInnerColorRed),
+            Key.laserInnerColorGreen: Double(defaults.laserInnerColorGreen),
+            Key.laserInnerColorBlue: Double(defaults.laserInnerColorBlue),
             Key.toggleEnabledHotKeyCode: ClickShortcutAction.toggleEnabled.defaultBinding!.keyCode,
             Key.toggleEnabledHotKeyModifiers: ClickShortcutAction.toggleEnabled.defaultBinding!.carbonModifiers,
             Key.toggleEnabledHotKeyIsEnabled: true,

--- a/Sources/ClickLight/SettingsWindowController.swift
+++ b/Sources/ClickLight/SettingsWindowController.swift
@@ -279,6 +279,24 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
         }
     }
 
+    func applyLaserColor(_ color: NSColor) {
+        guard let rgb = color.usingColorSpace(.deviceRGB) else { return }
+        update {
+            $0.laserColorRed = rgb.redComponent
+            $0.laserColorGreen = rgb.greenComponent
+            $0.laserColorBlue = rgb.blueComponent
+        }
+    }
+
+    func applyLaserInnerColor(_ color: NSColor) {
+        guard let rgb = color.usingColorSpace(.deviceRGB) else { return }
+        update {
+            $0.laserInnerColorRed = rgb.redComponent
+            $0.laserInnerColorGreen = rgb.greenComponent
+            $0.laserInnerColorBlue = rgb.blueComponent
+        }
+    }
+
     func resetToDefaults() {
         apply(.defaults)
     }


### PR DESCRIPTION
## Summary
- add outer and inner laser pointer color settings under Visual Style → Color
- derive the middle laser color by blending the outer and inner colors
- persist the new laser color settings and apply them to the cursor and drag stroke

## Testing
- Built with `./build-app.sh`
- Installed locally to `/Applications/ClickLight.app` and launched for manual testing