### PR TITLE
Open settings menu actions to relevant panes

### DIFF
--- a/Sources/ClickLight/AppDelegate.swift
+++ b/Sources/ClickLight/AppDelegate.swift
@@ -19,7 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         launchAtLogin: launchAtLogin,
         onCheckForUpdates: { UpdateChecker.shared.checkForUpdates() },
         updatesAreConfigured: { UpdateChecker.shared.isConfigured },
-        onOpenSettings: { [weak self] in self?.openSettings() },
+        onOpenSettings: { [weak self] pane in self?.openSettings(selecting: pane) },
         onQuit: { NSApplication.shared.terminate(nil) },
         onMenuWillOpen: { [weak self] in
             self?.hotKeyManager.unregisterAll()
@@ -212,7 +212,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.terminate(nil)
     }
 
-    private func openSettings() {
+    private func openSettings(selecting pane: SettingsPane? = nil) {
         let controller = settingsWindowController ?? SettingsWindowController(
             settingsStore: settingsStore,
             profileStore: profileStore,
@@ -224,6 +224,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         )
         settingsWindowController = controller
-        controller.show()
+        controller.show(selecting: pane)
     }
 }

--- a/Sources/ClickLight/ClickLightSettingsView.swift
+++ b/Sources/ClickLight/ClickLightSettingsView.swift
@@ -6,7 +6,6 @@ struct ClickLightSettingsView: View {
     @ObservedObject var viewModel: ClickLightSettingsViewModel
     @ObservedObject var profileStore: ClickProfileStore
     @ObservedObject var activityStore: ClickActivityStore
-    @State private var selectedPane: SettingsPane = .general
     @State private var showResetConfirmation = false
     @State private var showShortcutResetConfirmation = false
     @State private var showActivityResetConfirmation = false
@@ -16,7 +15,7 @@ struct ClickLightSettingsView: View {
     var body: some View {
         NavigationSplitView {
             VStack(spacing: 0) {
-                List(SettingsPane.allCases, id: \.self, selection: $selectedPane) { pane in
+                List(SettingsPane.allCases, id: \.self, selection: $viewModel.selectedPane) { pane in
                     Label {
                         Text(pane.title)
                             .font(.system(size: 13, weight: .medium))
@@ -60,7 +59,7 @@ struct ClickLightSettingsView: View {
                     paneHeader
 
                     Group {
-                        switch selectedPane {
+                        switch viewModel.selectedPane {
                         case .general:
                             generalPane
                         case .style:
@@ -138,10 +137,10 @@ struct ClickLightSettingsView: View {
 
     private var paneHeader: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(selectedPane.title)
+            Text(viewModel.selectedPane.title)
                 .font(.system(size: 22, weight: .semibold))
                 .accessibilityAddTraits(.isHeader)
-            Text(selectedPane.subtitle)
+            Text(viewModel.selectedPane.subtitle)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }
@@ -1262,7 +1261,7 @@ private final class InteractiveClickPreviewView: NSView {
     }
 }
 
-private enum SettingsPane: String, CaseIterable, Hashable {
+enum SettingsPane: String, CaseIterable, Hashable {
     case general
     case events
     case style

--- a/Sources/ClickLight/SettingsWindowController.swift
+++ b/Sources/ClickLight/SettingsWindowController.swift
@@ -43,12 +43,18 @@ final class SettingsWindowController: NSWindowController {
         nil
     }
 
-    func show() {
+    func show(selecting pane: SettingsPane? = nil) {
         guard let window else { return }
         NSApp.activate(ignoringOtherApps: true)
         showWindow(nil)
         window.makeKeyAndOrderFront(nil)
         window.orderFrontRegardless()
+        if let pane {
+            viewModel.selectedPane = pane
+            Task { @MainActor [weak self] in
+                self?.viewModel.selectedPane = pane
+            }
+        }
         viewModel.refreshSystemState()
     }
 
@@ -70,6 +76,7 @@ final class ClickLightSettingsViewModel: NSObject, ObservableObject {
     @Published private(set) var accessibilityTrusted: Bool = false
     @Published private(set) var inputMonitoringTrusted: Bool = false
     @Published var launchAtLoginErrorMessage: String?
+    @Published var selectedPane: SettingsPane = .general
     @Published private(set) var shortcutErrors: [ClickShortcutAction: String] = [:]
     @Published private(set) var hotKeyRegistrationIssues: [ClickShortcutAction: String] = [:]
 

--- a/Sources/ClickLight/SettingsWindowController.swift
+++ b/Sources/ClickLight/SettingsWindowController.swift
@@ -51,9 +51,6 @@ final class SettingsWindowController: NSWindowController {
         window.orderFrontRegardless()
         if let pane {
             viewModel.selectedPane = pane
-            Task { @MainActor [weak self] in
-                self?.viewModel.selectedPane = pane
-            }
         }
         viewModel.refreshSystemState()
     }

--- a/Sources/ClickLight/StatusController.swift
+++ b/Sources/ClickLight/StatusController.swift
@@ -11,7 +11,7 @@ final class StatusController: NSObject {
     private let launchAtLogin: LaunchAtLoginManaging
     private let onCheckForUpdates: () -> Void
     private let updatesAreConfigured: () -> Bool
-    private let onOpenSettings: () -> Void
+    private let onOpenSettings: (SettingsPane?) -> Void
     private let onQuit: () -> Void
     private let onMenuWillOpen: () -> Void
     private let onMenuDidClose: () -> Void
@@ -25,7 +25,7 @@ final class StatusController: NSObject {
         launchAtLogin: LaunchAtLoginManaging,
         onCheckForUpdates: @escaping () -> Void,
         updatesAreConfigured: @escaping () -> Bool,
-        onOpenSettings: @escaping () -> Void,
+        onOpenSettings: @escaping (SettingsPane?) -> Void,
         onQuit: @escaping () -> Void,
         onMenuWillOpen: @escaping () -> Void = {},
         onMenuDidClose: @escaping () -> Void = {}
@@ -335,7 +335,7 @@ final class StatusController: NSObject {
             menu.addItem(selectedCustom)
         }
 
-        let configureCustom = NSMenuItem(title: "Configure Custom Colors...", action: #selector(openSettings), keyEquivalent: "")
+        let configureCustom = NSMenuItem(title: "Configure Custom Colors...", action: #selector(openVisualStyleSettings), keyEquivalent: "")
         configureCustom.target = self
         menu.addItem(configureCustom)
 
@@ -364,7 +364,7 @@ final class StatusController: NSObject {
         }
 
         menu.addItem(.separator())
-        let manageItem = NSMenuItem(title: "Manage Profiles...", action: #selector(openSettings), keyEquivalent: "")
+        let manageItem = NSMenuItem(title: "Manage Profiles...", action: #selector(openProfileSettings), keyEquivalent: "")
         manageItem.target = self
         menu.addItem(manageItem)
 
@@ -378,7 +378,15 @@ final class StatusController: NSObject {
     }
 
     @objc private func openSettings() {
-        onOpenSettings()
+        onOpenSettings(nil)
+    }
+
+    @objc private func openProfileSettings() {
+        onOpenSettings(.profiles)
+    }
+
+    @objc private func openVisualStyleSettings() {
+        onOpenSettings(.style)
     }
 
     @objc private func togglePress(_ sender: NSMenuItem) {


### PR DESCRIPTION
## Summary
- Let status-menu settings actions request a specific Settings pane.
- Move the selected Settings pane into the shared view model so AppKit menu actions can update it.
- Open `Manage Profiles...` on Profiles and `Configure Custom Colors...` on Visual Style.

## Verification
- `swift build`