### PR TITLE
fix: left-align GitHub Link

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -84,7 +84,7 @@ button:disabled {
 .topbar {
   align-items: center;
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   left: 0;
   padding: 24px;
   position: fixed;


### PR DESCRIPTION
Hey, so this one just brings the GitHub Icon on the website to the left, might be easier as the preview of the app can have different height.

## Summary
This changes the position of the GitHub Link Icon on the website because on smaller screens its blocking the application preview.
Before:
<img width="365" height="226" alt="Before" src="https://github.com/user-attachments/assets/7b18c578-2414-483f-8f9d-54c03720b5f0" />

After:
<img width="1295" height="414" alt="After" src="https://github.com/user-attachments/assets/a679c7d8-698e-4ebc-a577-32aca7c6a39c" />



## Test Plan

- [x] Built locally with `./build-app.sh`
- [x] Manually tested the changed behavior

## Checklist

- [x] I updated documentation if user-visible behavior changed
- [x] I included a screenshot or recording for visible UI changes, if relevant
- [x] I did not include credentials, private keys, generated app bundles, or local system files
