### PR TITLE
Fix Homebrew install command shown on website

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -260,7 +260,7 @@ button:disabled {
   backdrop-filter: blur(24px);
   background: rgba(10, 10, 14, 0.42);
   border: 1px solid var(--stroke);
-  border-radius: 999px;
+  border-radius: 18px;
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.24);
   display: flex;
   gap: 10px;
@@ -274,9 +274,8 @@ button:disabled {
   font-family: "SF Mono", ui-monospace, Menlo, Monaco, Consolas, monospace;
   font-size: 0.88rem;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .install button {

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -302,7 +302,7 @@ function compactCount(value: number): string {
 
 let nextAnimationId = 0;
 const installCommand =
-  "brew install --cask aurorascharff/clicklight/clicklight";
+  "brew tap aurorascharff/clicklight https://github.com/aurorascharff/ClickLight\nbrew install --cask aurorascharff/clicklight/clicklight";
 
 // Mirrors Sources/ClickLight/ClickSettingOptions.swift so the submenu shows
 // the same presets the macOS app does.


### PR DESCRIPTION
## Summary
- copy the existing two-step Homebrew install flow from the website instead of the unsupported shorthand install alone
- show both commands legibly in the install control

## Why
The website currently copies `brew install --cask aurorascharff/clicklight/clicklight`, which makes Homebrew look for a separate `aurorascharff/homebrew-clicklight` tap repository. That repository does not exist because the cask currently lives in the main ClickLight repository. This is the failure reported in #76.

This PR keeps the current repository setup and makes the website use the working flow already documented in the README:

```bash
brew tap aurorascharff/clicklight https://github.com/aurorascharff/ClickLight
brew install --cask aurorascharff/clicklight/clicklight
```

A future separate tap repository could make the one-line install work without this explicit tap URL.

## Validation
- `npm run build` in `website/`
- `git diff --check`

Addresses #76.
